### PR TITLE
Enable scroll restoration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,59 +1,62 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+	experimental: {
+		scrollRestoration: true,
+	},
 	output: 'standalone',
 	images: {
 		minimumCacheTTL: 60 * 60 * 24 * 30, // 30 days
 		remotePatterns: [
-		  {
-			protocol: 'https',
-			hostname: 'image.tmdb.org',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'picsum.photos',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'm.media-amazon.com',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'static.debridmediamanager.com',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'images.metahub.space',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'fakeimg.pl',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'media.kitsu.io',
-			port: '',
-			pathname: '/**',
-		  },
-		  {
-			protocol: 'https',
-			hostname: 'cdn.myanimelist.net',
-			port: '',
-			pathname: '/**',
-		  }
+			{
+				protocol: 'https',
+				hostname: 'image.tmdb.org',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'picsum.photos',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'm.media-amazon.com',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'static.debridmediamanager.com',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'images.metahub.space',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'fakeimg.pl',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'media.kitsu.io',
+				port: '',
+				pathname: '/**',
+			},
+			{
+				protocol: 'https',
+				hostname: 'cdn.myanimelist.net',
+				port: '',
+				pathname: '/**',
+			},
 		],
-	  },
+	},
 	reactStrictMode: false,
 	publicRuntimeConfig: {
 		// Will be available on both server and client


### PR DESCRIPTION
This PR enables scroll restoration for the app, using next.js's experimental `scrollRestoration` feature, which overrides the default browser behavior of restoring the scroll position to the last saved position.

The scenario is this:

1. User navigates to a page with a scrollable content.
2. User scrolls down to the bottom of the page.
3. User navigates to another page.
4. User navigates back to the previous page.
5. Result
  - Expected behavior: The scroll position is restored to the last saved position, which is the bottom of the page.
  - Actual behavior: The scroll position is restored to the top of the page.

This is my first contribution to this repo, let me know if I'm missing anything!

Thanks for your great work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced experimental scroll restoration feature for improved navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->