### PR TITLE
feat: add Authorization header support to Stremio API endpoints

### DIFF
--- a/src/pages/api/stremio/cast/[imdbid].ts
+++ b/src/pages/api/stremio/cast/[imdbid].ts
@@ -1,5 +1,5 @@
 import { repository as db } from '@/services/repository';
-import { generateUserId } from '@/utils/castApiHelpers';
+import { extractToken, generateUserId } from '@/utils/castApiHelpers';
 import { getClientIpFromRequest } from '@/utils/clientIp';
 import { getStreamUrl } from '@/utils/getStreamUrl';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -9,24 +9,24 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 	res.setHeader('access-control-allow-origin', '*');
 
-	const { imdbid, token, hash, fileId, mediaType } = req.query;
+	const { imdbid, hash, fileId, mediaType } = req.query;
+	const token = extractToken(req);
 	if (!token || !hash || !fileId || !mediaType) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash", "fileId" or "mediaType" query parameter',
+			errorMessage: 'Missing "token", "hash", "fileId" or "mediaType" parameter',
 		});
 		return;
 	}
 	if (
 		typeof imdbid !== 'string' ||
-		typeof token !== 'string' ||
 		typeof hash !== 'string' ||
 		typeof fileId !== 'string' ||
 		typeof mediaType !== 'string'
 	) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Invalid "token", "hash", "fileId" or "mediaType" query parameter',
+			errorMessage: 'Invalid "token", "hash", "fileId" or "mediaType" parameter',
 		});
 		return;
 	}

--- a/src/pages/api/stremio/cast/anime/[anidbid].ts
+++ b/src/pages/api/stremio/cast/anime/[anidbid].ts
@@ -1,5 +1,5 @@
 import { repository as db } from '@/services/repository';
-import { generateUserId } from '@/utils/castApiHelpers';
+import { extractToken, generateUserId } from '@/utils/castApiHelpers';
 import { getClientIpFromRequest } from '@/utils/clientIp';
 import { getStreamUrl } from '@/utils/getStreamUrl';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -7,23 +7,23 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 	res.setHeader('access-control-allow-origin', '*');
 
-	const { anidbid, token, hash, fileIds } = req.query;
+	const { anidbid, hash, fileIds } = req.query;
+	const token = extractToken(req);
 	if (!token || !hash || !fileIds) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Missing "token", "hash" or "fileIds" parameter',
 		});
 		return;
 	}
 	if (
 		typeof anidbid !== 'string' ||
-		typeof token !== 'string' ||
 		typeof hash !== 'string' ||
 		(!Array.isArray(fileIds) && typeof fileIds !== 'string')
 	) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Invalid "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Invalid "token", "hash" or "fileIds" parameter',
 		});
 		return;
 	}

--- a/src/pages/api/stremio/cast/movie/[imdbid].ts
+++ b/src/pages/api/stremio/cast/movie/[imdbid].ts
@@ -1,5 +1,5 @@
 import { repository as db } from '@/services/repository';
-import { generateUserId } from '@/utils/castApiHelpers';
+import { extractToken, generateUserId } from '@/utils/castApiHelpers';
 import { getClientIpFromRequest } from '@/utils/clientIp';
 import { getBiggestFileStreamUrl } from '@/utils/getStreamUrl';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -9,18 +9,19 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 	res.setHeader('access-control-allow-origin', '*');
 
-	const { imdbid, token, hash } = req.query;
+	const { imdbid, hash } = req.query;
+	const token = extractToken(req);
 	if (!token || !hash) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Missing "token" or "hash" query parameter',
+			errorMessage: 'Missing "token" or "hash" parameter',
 		});
 		return;
 	}
-	if (typeof imdbid !== 'string' || typeof token !== 'string' || typeof hash !== 'string') {
+	if (typeof imdbid !== 'string' || typeof hash !== 'string') {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Invalid "token" or "hash" query parameter',
+			errorMessage: 'Invalid "token" or "hash" parameter',
 		});
 		return;
 	}

--- a/src/pages/api/stremio/cast/series/[imdbid].ts
+++ b/src/pages/api/stremio/cast/series/[imdbid].ts
@@ -1,5 +1,5 @@
 import { repository as db } from '@/services/repository';
-import { generateUserId } from '@/utils/castApiHelpers';
+import { extractToken, generateUserId } from '@/utils/castApiHelpers';
 import { getClientIpFromRequest } from '@/utils/clientIp';
 import { getStreamUrl } from '@/utils/getStreamUrl';
 import { NextApiRequest, NextApiResponse } from 'next';
@@ -9,23 +9,23 @@ import { NextApiRequest, NextApiResponse } from 'next';
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
 	res.setHeader('access-control-allow-origin', '*');
 
-	const { imdbid, token, hash, fileIds } = req.query;
+	const { imdbid, hash, fileIds } = req.query;
+	const token = extractToken(req);
 	if (!token || !hash || !fileIds) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Missing "token", "hash" or "fileIds" parameter',
 		});
 		return;
 	}
 	if (
 		typeof imdbid !== 'string' ||
-		typeof token !== 'string' ||
 		typeof hash !== 'string' ||
 		(!Array.isArray(fileIds) && typeof fileIds !== 'string')
 	) {
 		res.status(400).json({
 			status: 'error',
-			errorMessage: 'Invalid "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Invalid "token", "hash" or "fileIds" parameter',
 		});
 		return;
 	}

--- a/src/services/movieCleaner.test.ts
+++ b/src/services/movieCleaner.test.ts
@@ -17,6 +17,10 @@ const {
 	sortByFileSizeMock: vi.fn(),
 }));
 
+vi.mock('./mdblistClient', () => ({
+	getMdblistClient: vi.fn(() => ({})),
+}));
+
 vi.mock('@/utils/checks', () => ({
 	filterByMovieConditions: filterByMovieConditionsMock,
 	getAllPossibleTitles: getAllPossibleTitlesMock,

--- a/src/services/tvCleaner.test.ts
+++ b/src/services/tvCleaner.test.ts
@@ -23,6 +23,10 @@ const {
 	sortByFileSizeMock: vi.fn(),
 }));
 
+vi.mock('./mdblistClient', () => ({
+	getMdblistClient: vi.fn(() => ({})),
+}));
+
 vi.mock('@/utils/checks', () => ({
 	filterByTvConditions: filterByTvConditionsMock,
 	getAllPossibleTitles: getAllPossibleTitlesMock,

--- a/src/test/api/info/movie-trailer-fallback.test.ts
+++ b/src/test/api/info/movie-trailer-fallback.test.ts
@@ -98,9 +98,17 @@ describe('/api/info/movie - trailer fallback sources', () => {
 			json: vi.fn(),
 		} as unknown as NextApiResponse;
 
-		process.env.TMDB_KEY = 'test-key';
-		await handler(req, res);
-		delete process.env.TMDB_KEY;
+		const previousTmdbKey = process.env.TMDB_KEY;
+		try {
+			process.env.TMDB_KEY = 'test-key';
+			await handler(req, res);
+		} finally {
+			if (previousTmdbKey === undefined) {
+				delete process.env.TMDB_KEY;
+			} else {
+				process.env.TMDB_KEY = previousTmdbKey;
+			}
+		}
 
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith(

--- a/src/test/api/info/movie-trailer-fallback.test.ts
+++ b/src/test/api/info/movie-trailer-fallback.test.ts
@@ -98,7 +98,9 @@ describe('/api/info/movie - trailer fallback sources', () => {
 			json: vi.fn(),
 		} as unknown as NextApiResponse;
 
+		process.env.TMDB_KEY = 'test-key';
 		await handler(req, res);
+		delete process.env.TMDB_KEY;
 
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith(

--- a/src/test/api/info/show-trailer-fallback.test.ts
+++ b/src/test/api/info/show-trailer-fallback.test.ts
@@ -102,7 +102,9 @@ describe('/api/info/show - trailer fallback sources', () => {
 			json: vi.fn(),
 		} as unknown as NextApiResponse;
 
+		process.env.TMDB_KEY = 'test-key';
 		await handler(req, res);
+		delete process.env.TMDB_KEY;
 
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith(

--- a/src/test/api/info/show-trailer-fallback.test.ts
+++ b/src/test/api/info/show-trailer-fallback.test.ts
@@ -102,9 +102,17 @@ describe('/api/info/show - trailer fallback sources', () => {
 			json: vi.fn(),
 		} as unknown as NextApiResponse;
 
-		process.env.TMDB_KEY = 'test-key';
-		await handler(req, res);
-		delete process.env.TMDB_KEY;
+		const previousTmdbKey = process.env.TMDB_KEY;
+		try {
+			process.env.TMDB_KEY = 'test-key';
+			await handler(req, res);
+		} finally {
+			if (previousTmdbKey === undefined) {
+				delete process.env.TMDB_KEY;
+			} else {
+				process.env.TMDB_KEY = previousTmdbKey;
+			}
+		}
 
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith(

--- a/src/test/api/stremio/cast/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/[imdbid].test.ts
@@ -9,16 +9,14 @@ vi.mock('@/services/repository');
 vi.mock('@/utils/getStreamUrl', () => ({
 	getStreamUrl: vi.fn(),
 }));
-vi.mock('@/utils/castApiHelpers', () => ({
-	extractToken: vi.fn(
-		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
-			const auth = req.headers?.authorization;
-			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
-			return req.query?.token ?? null;
-		}
-	),
-	generateUserId: vi.fn(),
-}));
+vi.mock('@/utils/castApiHelpers', async () => {
+	const actual =
+		await vi.importActual<typeof import('@/utils/castApiHelpers')>('@/utils/castApiHelpers');
+	return {
+		...actual,
+		generateUserId: vi.fn(),
+	};
+});
 
 const mockRepository = vi.mocked(repository);
 const mockGetStreamUrl = vi.mocked(getStreamUrl);

--- a/src/test/api/stremio/cast/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/[imdbid].test.ts
@@ -10,6 +10,13 @@ vi.mock('@/utils/getStreamUrl', () => ({
 	getStreamUrl: vi.fn(),
 }));
 vi.mock('@/utils/castApiHelpers', () => ({
+	extractToken: vi.fn(
+		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
+			const auth = req.headers?.authorization;
+			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
+			return req.query?.token ?? null;
+		}
+	),
 	generateUserId: vi.fn(),
 }));
 
@@ -34,7 +41,7 @@ describe('/api/stremio/cast/[imdbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash", "fileId" or "mediaType" query parameter',
+			errorMessage: 'Missing "token", "hash", "fileId" or "mediaType" parameter',
 		});
 	});
 
@@ -49,7 +56,7 @@ describe('/api/stremio/cast/[imdbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Invalid "token", "hash", "fileId" or "mediaType" query parameter',
+			errorMessage: 'Invalid "token", "hash", "fileId" or "mediaType" parameter',
 		});
 	});
 

--- a/src/test/api/stremio/cast/anime/[anidbid].test.ts
+++ b/src/test/api/stremio/cast/anime/[anidbid].test.ts
@@ -8,16 +8,14 @@ const { mockGenerateUserId, mockSaveCast, mockGetStreamUrl } = vi.hoisted(() => 
 	mockGetStreamUrl: vi.fn(),
 }));
 
-vi.mock('@/utils/castApiHelpers', () => ({
-	extractToken: vi.fn(
-		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
-			const auth = req.headers?.authorization;
-			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
-			return req.query?.token ?? null;
-		}
-	),
-	generateUserId: mockGenerateUserId,
-}));
+vi.mock('@/utils/castApiHelpers', async () => {
+	const actual =
+		await vi.importActual<typeof import('@/utils/castApiHelpers')>('@/utils/castApiHelpers');
+	return {
+		...actual,
+		generateUserId: mockGenerateUserId,
+	};
+});
 
 vi.mock('@/services/repository', () => ({
 	repository: {

--- a/src/test/api/stremio/cast/anime/[anidbid].test.ts
+++ b/src/test/api/stremio/cast/anime/[anidbid].test.ts
@@ -9,6 +9,13 @@ const { mockGenerateUserId, mockSaveCast, mockGetStreamUrl } = vi.hoisted(() => 
 }));
 
 vi.mock('@/utils/castApiHelpers', () => ({
+	extractToken: vi.fn(
+		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
+			const auth = req.headers?.authorization;
+			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
+			return req.query?.token ?? null;
+		}
+	),
 	generateUserId: mockGenerateUserId,
 }));
 
@@ -44,7 +51,7 @@ describe('/api/stremio/cast/anime/[anidbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Missing "token", "hash" or "fileIds" parameter',
 		});
 	});
 
@@ -59,7 +66,7 @@ describe('/api/stremio/cast/anime/[anidbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Invalid "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Invalid "token", "hash" or "fileIds" parameter',
 		});
 	});
 

--- a/src/test/api/stremio/cast/movie/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/movie/[imdbid].test.ts
@@ -14,16 +14,14 @@ vi.mock('@/services/repository', () => ({
 	},
 }));
 
-vi.mock('@/utils/castApiHelpers', () => ({
-	extractToken: vi.fn(
-		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
-			const auth = req.headers?.authorization;
-			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
-			return req.query?.token ?? null;
-		}
-	),
-	generateUserId: mockGenerateUserId,
-}));
+vi.mock('@/utils/castApiHelpers', async () => {
+	const actual =
+		await vi.importActual<typeof import('@/utils/castApiHelpers')>('@/utils/castApiHelpers');
+	return {
+		...actual,
+		generateUserId: mockGenerateUserId,
+	};
+});
 
 vi.mock('@/utils/getStreamUrl', () => ({
 	getBiggestFileStreamUrl: mockGetBiggestFileStreamUrl,

--- a/src/test/api/stremio/cast/movie/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/movie/[imdbid].test.ts
@@ -15,6 +15,13 @@ vi.mock('@/services/repository', () => ({
 }));
 
 vi.mock('@/utils/castApiHelpers', () => ({
+	extractToken: vi.fn(
+		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
+			const auth = req.headers?.authorization;
+			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
+			return req.query?.token ?? null;
+		}
+	),
 	generateUserId: mockGenerateUserId,
 }));
 
@@ -36,7 +43,7 @@ describe('/api/stremio/cast/movie/[imdbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Missing "token" or "hash" query parameter',
+			errorMessage: 'Missing "token" or "hash" parameter',
 		});
 	});
 

--- a/src/test/api/stremio/cast/series/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/series/[imdbid].test.ts
@@ -15,6 +15,13 @@ vi.mock('@/services/repository', () => ({
 }));
 
 vi.mock('@/utils/castApiHelpers', () => ({
+	extractToken: vi.fn(
+		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
+			const auth = req.headers?.authorization;
+			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
+			return req.query?.token ?? null;
+		}
+	),
 	generateUserId: mockGenerateUserId,
 }));
 
@@ -37,7 +44,7 @@ describe('/api/stremio/cast/series/[imdbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(400);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'Missing "token", "hash" or "fileIds" query parameter',
+			errorMessage: 'Missing "token", "hash" or "fileIds" parameter',
 		});
 	});
 

--- a/src/test/api/stremio/cast/series/[imdbid].test.ts
+++ b/src/test/api/stremio/cast/series/[imdbid].test.ts
@@ -14,16 +14,14 @@ vi.mock('@/services/repository', () => ({
 	},
 }));
 
-vi.mock('@/utils/castApiHelpers', () => ({
-	extractToken: vi.fn(
-		(req: { query: Record<string, string>; headers: Record<string, string> }) => {
-			const auth = req.headers?.authorization;
-			if (auth && auth.toLowerCase().startsWith('bearer ')) return auth.substring(7).trim();
-			return req.query?.token ?? null;
-		}
-	),
-	generateUserId: mockGenerateUserId,
-}));
+vi.mock('@/utils/castApiHelpers', async () => {
+	const actual =
+		await vi.importActual<typeof import('@/utils/castApiHelpers')>('@/utils/castApiHelpers');
+	return {
+		...actual,
+		generateUserId: mockGenerateUserId,
+	};
+});
 
 vi.mock('@/utils/getStreamUrl', () => ({
 	getStreamUrl: mockGetStreamUrl,

--- a/src/utils/castApiHelpers.test.ts
+++ b/src/utils/castApiHelpers.test.ts
@@ -1,7 +1,13 @@
 import crypto from 'crypto';
+import { NextApiRequest, NextApiResponse } from 'next';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { generateLegacyUserId, generateUserId } from './castApiHelpers';
+import {
+	extractToken,
+	generateLegacyUserId,
+	generateUserId,
+	validateToken,
+} from './castApiHelpers';
 
 vi.mock('@/services/realDebrid', () => ({
 	getCurrentUser: vi.fn(),
@@ -51,5 +57,80 @@ describe('castApiHelpers', () => {
 			.replace(/=/g, '')
 			.slice(0, 5);
 		expect(result).toBe(expected);
+	});
+});
+
+function mockReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
+	return {
+		query: {},
+		body: {},
+		headers: {},
+		...overrides,
+	} as unknown as NextApiRequest;
+}
+
+function mockRes(): NextApiResponse {
+	const res = {
+		status: vi.fn().mockReturnThis(),
+		json: vi.fn().mockReturnThis(),
+	};
+	return res as unknown as NextApiResponse;
+}
+
+describe('extractToken', () => {
+	it('returns token from Authorization Bearer header', () => {
+		const req = mockReq({ headers: { authorization: 'Bearer mytoken123' } });
+		expect(extractToken(req)).toBe('mytoken123');
+	});
+
+	it('falls back to query param when no header', () => {
+		const req = mockReq({ query: { token: 'querytoken' } });
+		expect(extractToken(req)).toBe('querytoken');
+	});
+
+	it('falls back to body token when no header or query', () => {
+		const req = mockReq({ body: { token: 'bodytoken' } });
+		expect(extractToken(req)).toBe('bodytoken');
+	});
+
+	it('prefers header over query and body', () => {
+		const req = mockReq({
+			headers: { authorization: 'Bearer headertoken' },
+			query: { token: 'querytoken' },
+			body: { token: 'bodytoken' },
+		});
+		expect(extractToken(req)).toBe('headertoken');
+	});
+
+	it('returns null when no token anywhere', () => {
+		const req = mockReq();
+		expect(extractToken(req)).toBeNull();
+	});
+
+	it('returns null for malformed Authorization header (no Bearer prefix)', () => {
+		const req = mockReq({ headers: { authorization: 'Basic sometoken' } });
+		expect(extractToken(req)).toBeNull();
+	});
+
+	it('returns null for empty Bearer token', () => {
+		const req = mockReq({ headers: { authorization: 'Bearer ' } });
+		expect(extractToken(req)).toBeNull();
+	});
+});
+
+describe('validateToken', () => {
+	it('returns token from Authorization header', () => {
+		const req = mockReq({ headers: { authorization: 'Bearer validtoken' } });
+		const res = mockRes();
+		expect(validateToken(req, res)).toBe('validtoken');
+		expect(res.status).not.toHaveBeenCalled();
+	});
+
+	it('returns 401 when no token', () => {
+		const req = mockReq();
+		const res = mockRes();
+		expect(validateToken(req, res)).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(401);
+		expect(res.json).toHaveBeenCalledWith({ error: 'Invalid or missing token' });
 	});
 });

--- a/src/utils/castApiHelpers.test.ts
+++ b/src/utils/castApiHelpers.test.ts
@@ -78,6 +78,13 @@ function mockRes(): NextApiResponse {
 }
 
 describe('extractToken', () => {
+	it('returns null when Authorization header is an array', () => {
+		const req = mockReq({
+			headers: { authorization: ['Bearer tokenA', 'Bearer tokenB'] as any },
+		});
+		expect(extractToken(req)).toBeNull();
+	});
+
 	it('returns token from Authorization Bearer header', () => {
 		const req = mockReq({ headers: { authorization: 'Bearer mytoken123' } });
 		expect(extractToken(req)).toBe('mytoken123');

--- a/src/utils/castApiHelpers.test.ts
+++ b/src/utils/castApiHelpers.test.ts
@@ -112,6 +112,11 @@ describe('extractToken', () => {
 		expect(extractToken(req)).toBeNull();
 	});
 
+	it('accepts bearer header with lowercase scheme', () => {
+		const req = mockReq({ headers: { authorization: 'bearer mytoken123' } });
+		expect(extractToken(req)).toBe('mytoken123');
+	});
+
 	it('returns null for empty Bearer token', () => {
 		const req = mockReq({ headers: { authorization: 'Bearer ' } });
 		expect(extractToken(req)).toBeNull();

--- a/src/utils/castApiHelpers.test.ts
+++ b/src/utils/castApiHelpers.test.ts
@@ -117,6 +117,11 @@ describe('extractToken', () => {
 		expect(extractToken(req)).toBe('mytoken123');
 	});
 
+	it('accepts bearer header with tab or multiple spaces after scheme', () => {
+		const req = mockReq({ headers: { authorization: 'Bearer\t\tmytoken123' } });
+		expect(extractToken(req)).toBe('mytoken123');
+	});
+
 	it('returns null for empty Bearer token', () => {
 		const req = mockReq({ headers: { authorization: 'Bearer ' } });
 		expect(extractToken(req)).toBeNull();

--- a/src/utils/castApiHelpers.ts
+++ b/src/utils/castApiHelpers.ts
@@ -15,9 +15,25 @@ export const validateMethod = (
 	return true;
 };
 
+export const extractToken = (req: NextApiRequest): string | null => {
+	// Check Authorization: Bearer header first
+	const authHeader = req.headers.authorization;
+	if (authHeader && authHeader.startsWith('Bearer ')) {
+		const token = authHeader.substring(7).trim();
+		if (token) return token;
+	}
+	// Fall back to query param
+	const queryToken = req.query.token;
+	if (queryToken && typeof queryToken === 'string') return queryToken;
+	// Fall back to request body
+	const bodyToken = req.body?.token;
+	if (bodyToken && typeof bodyToken === 'string') return bodyToken;
+	return null;
+};
+
 export const validateToken = (req: NextApiRequest, res: NextApiResponse): string | null => {
-	const token = req.query.token || req.body.token;
-	if (!token || typeof token !== 'string') {
+	const token = extractToken(req);
+	if (!token) {
 		res.status(401).json({ error: 'Invalid or missing token' });
 		return null;
 	}

--- a/src/utils/castApiHelpers.ts
+++ b/src/utils/castApiHelpers.ts
@@ -18,9 +18,12 @@ export const validateMethod = (
 export const extractToken = (req: NextApiRequest): string | null => {
 	// Check Authorization: Bearer header first
 	const authHeader = req.headers.authorization;
-	if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
-		const token = authHeader.substring(7).trim();
-		if (token) return token;
+	if (authHeader) {
+		const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
+		if (bearerMatch) {
+			const token = bearerMatch[1].trim();
+			if (token) return token;
+		}
 	}
 	// Fall back to query param
 	const queryToken = req.query.token;

--- a/src/utils/castApiHelpers.ts
+++ b/src/utils/castApiHelpers.ts
@@ -18,7 +18,7 @@ export const validateMethod = (
 export const extractToken = (req: NextApiRequest): string | null => {
 	// Check Authorization: Bearer header first
 	const authHeader = req.headers.authorization;
-	if (authHeader) {
+	if (typeof authHeader === 'string') {
 		const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/i);
 		if (bearerMatch) {
 			const token = bearerMatch[1].trim();

--- a/src/utils/castApiHelpers.ts
+++ b/src/utils/castApiHelpers.ts
@@ -18,7 +18,7 @@ export const validateMethod = (
 export const extractToken = (req: NextApiRequest): string | null => {
 	// Check Authorization: Bearer header first
 	const authHeader = req.headers.authorization;
-	if (authHeader && authHeader.startsWith('Bearer ')) {
+	if (authHeader && authHeader.toLowerCase().startsWith('bearer ')) {
 		const token = authHeader.substring(7).trim();
 		if (token) return token;
 	}


### PR DESCRIPTION
Enhanced all /api/stremio endpoints to accept Real-Debrid tokens via:
- Authorization: Bearer <token> header (NEW)
- Query parameter: ?token=<token> (existing)
- Request body: { "token": "<token>" } (existing)

Changes:
- Updated validateToken() to check Authorization header first
- Added extractToken() helper for flexible token extraction
- Modified all cast endpoints to support header authentication
- Improved error messages to be parameter-location agnostic

Benefits:
- More secure (tokens not in URL/logs)
- Better REST API practices
- Backward compatible with existing query param usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Bearer token authentication via the Authorization header in addition to query/body tokens.

* **Improvements**
  * Clarified error messages for missing or invalid parameters (now refer to "parameter" rather than "query parameter").
  * Token handling/validation unified to use the new extractor and consistently return 401 for missing/invalid tokens.

* **Tests**
  * Added/expanded tests for token extraction and validation; updated mocks and adjusted test env handling and expectation strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->