### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/src/pages/api/info/movie.ts
+++ b/src/pages/api/info/movie.ts
@@ -82,7 +82,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			backdrop:
 				mdbResponse.backdrop ??
 				cinemetaResponse.meta?.background ??
-				'https://source.unsplash.com/random/1800x300?' + title,
+				`https://picsum.photos/seed/${encodeURIComponent(title)}/1800/300`,
 			year: mdbResponse.year ?? cinemetaResponse.meta?.releaseInfo ?? '????',
 			imdb_score: imdb_score ?? 0,
 			trailer,
@@ -93,7 +93,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			title: 'Unknown',
 			description: 'n/a',
 			poster: '',
-			backdrop: 'https://source.unsplash.com/random/1800x300?movie',
+			backdrop: 'https://picsum.photos/seed/movie/1800/300',
 			year: '????',
 			imdb_score: 0,
 			trailer: '',


### PR DESCRIPTION
`src/pages/api/info/movie.ts` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns 503 errors. Browser screenshots typically render a broken image icon instead of the intended placeholder.

You can verify in any browser:

```
curl -I https://source.unsplash.com/random/800x600?office
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces both deprecated movie-backdrop fallback URLs with seeded `picsum.photos` URLs of the same size, so a missing backdrop renders a stable per-title image instead of a 503.

#### Replacement details

Using `seed/${encodeURIComponent(title)}` gives a deterministic, unique-per-movie image (so it doesn't flicker on re-render). The fallback `backdrop` constant uses a fixed seed so the schema and behaviour stay identical.

**Trade-off**: this loses the topic-matching that `source.unsplash.com/random?<title>` used to provide. If you want the backdrop to actually look related to the movie title, swap the static URL for a one-line server-side fetch to a no-key Unsplash search (the [tteg HTTP API](https://github.com/kiluazen/tteg#http-api-no-install-needed) does exactly this — `https://tteg-api-53227342417.asia-south1.run.app/search?q=${title}&n=1&width=1800&height=300`). Happy to follow up with that variant if you'd prefer.

#### Background

I'm tracking deprecated image-CDN URLs across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built to make it easy to drop real Unsplash photos into projects without registering an Unsplash app or managing API keys. tteg isn't a dependency of this PR — the fix above is dependency-free. But if you ever want to swap the static replacement for something topic-aware, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

A 16k-files-across-885-repos summary of the deprecation is at [`kiluazen/tteg/RESEARCH.md`](https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback backdrop image handling for movies when primary data sources are unavailable, ensuring better visual consistency across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->