### PR TITLE
fix: replace deprecated unsplash fallback backdrop with picsum

### DIFF
--- a/src/pages/api/info/show.ts
+++ b/src/pages/api/info/show.ts
@@ -170,7 +170,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			backdrop:
 				mdbResponse?.backdrop ??
 				cinemetaResponse?.meta?.background ??
-				'https://source.unsplash.com/random/1800x300?' + title,
+				'https://picsum.photos/1800/300?random=' + encodeURIComponent(title),
 			season_count,
 			season_names,
 			has_specials,

--- a/src/pages/api/info/show.ts
+++ b/src/pages/api/info/show.ts
@@ -170,7 +170,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			backdrop:
 				mdbResponse?.backdrop ??
 				cinemetaResponse?.meta?.background ??
-				'https://picsum.photos/1800/300?random=' + encodeURIComponent(title),
+				`https://picsum.photos/seed/${encodeURIComponent(title)}/1800/300`,
 			season_count,
 			season_names,
 			has_specials,


### PR DESCRIPTION
The fallback backdrop URL ('source.unsplash.com/random') is returning 503 errors as the endpoint has been deprecated, causing broken images when MDB and Cinemeta both fail to return a backdrop.

Replaced with 'picsum.photos' which serves random images at the same dimensions and is actively maintained. Also wrapped the tittle in 'encodeURIComponent()' to prevent URL breakage on titles with special characters (colons, apostrophes, etc).


Fixes #232
FIxes #235 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback backdrop image behavior when primary sources are unavailable: now uses a seeded image service for consistent results and safely encodes titles to prevent broken or invalid image URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->