### PR TITLE
feat: add Torrin as a supported debrid service

### DIFF
--- a/prisma/migrations/20260711_add_torrin_cast_tables/migration.sql
+++ b/prisma/migrations/20260711_add_torrin_cast_tables/migration.sql
@@ -1,0 +1,29 @@
+-- CreateTable
+CREATE TABLE `TorrinCast` (
+    `id` VARCHAR(191) NOT NULL,
+    `imdbId` VARCHAR(191) NOT NULL,
+    `userId` VARCHAR(191) NOT NULL,
+    `hash` VARCHAR(191) NOT NULL,
+    `url` TEXT NOT NULL,
+    `updatedAt` DATETIME(3) NOT NULL,
+    `size` BIGINT NOT NULL DEFAULT 0,
+    `link` TEXT NULL,
+
+    INDEX `TorrinCast_imdbId_userId_updatedAt_idx`(`imdbId`, `userId`, `updatedAt`),
+    UNIQUE INDEX `TorrinCast_imdbId_userId_hash_key`(`imdbId`, `userId`, `hash`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `TorrinCastProfile` (
+    `userId` VARCHAR(191) NOT NULL,
+    `baseUrl` TEXT NOT NULL,
+    `apiKey` TEXT NOT NULL,
+    `updatedAt` DATETIME(3) NOT NULL,
+    `movieMaxSize` DOUBLE NOT NULL DEFAULT 0,
+    `episodeMaxSize` DOUBLE NOT NULL DEFAULT 0,
+    `otherStreamsLimit` INTEGER NOT NULL DEFAULT 5,
+    `hideCastOption` BOOLEAN NOT NULL DEFAULT false,
+
+    PRIMARY KEY (`userId`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/prisma/migrations/20260729_add_torrin_cast_baseurl/migration.sql
+++ b/prisma/migrations/20260729_add_torrin_cast_baseurl/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `TorrinCast` ADD COLUMN `baseUrl` TEXT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -230,6 +230,31 @@ model AllDebridCast {
   @@index([imdbId, userId, updatedAt])
 }
 
+model TorrinCast {
+  id        String   @id @default(uuid())
+  imdbId    String
+  userId    String
+  hash      String
+  url       String   @db.Text
+  updatedAt DateTime @updatedAt
+  size      BigInt   @default(0)
+  link      String?  @db.Text
+
+  @@unique([imdbId, userId, hash])
+  @@index([imdbId, userId, updatedAt])
+}
+
+model TorrinCastProfile {
+  userId            String   @id
+  baseUrl           String   @db.Text
+  apiKey            String   @db.Text
+  updatedAt         DateTime @updatedAt
+  movieMaxSize      Float    @default(0)
+  episodeMaxSize    Float    @default(0)
+  otherStreamsLimit Int      @default(5)
+  hideCastOption    Boolean  @default(false)
+}
+
 model AllDebridCastProfile {
   userId            String   @id
   apiKey            String   @db.Text

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -239,6 +239,7 @@ model TorrinCast {
   updatedAt DateTime @updatedAt
   size      BigInt   @default(0)
   link      String?  @db.Text
+  baseUrl   String?  @db.Text
 
   @@unique([imdbId, userId, hash])
   @@index([imdbId, userId, updatedAt])

--- a/src/components/CastSettingsPanel.tsx
+++ b/src/components/CastSettingsPanel.tsx
@@ -8,10 +8,11 @@ import {
 } from '../utils/browserStorage';
 import { defaultEpisodeSize, defaultMovieSize, defaultOtherStreamsLimit } from '../utils/settings';
 import { updateTorBoxSizeLimits } from '../utils/torboxCastApiClient';
+import { updateTorrinSizeLimits } from '../utils/torrinCastApiClient';
 
 interface CastSettingsPanelProps {
-	service: 'rd' | 'ad' | 'tb';
-	accentColor: 'green' | 'yellow' | 'purple';
+	service: 'rd' | 'ad' | 'tb' | 'tr';
+	accentColor: 'green' | 'yellow' | 'purple' | 'sky';
 }
 
 export const CastSettingsPanel = ({ service, accentColor }: CastSettingsPanelProps) => {
@@ -43,6 +44,11 @@ export const CastSettingsPanel = ({ service, accentColor }: CastSettingsPanelPro
 			border: 'border-purple-500/30',
 			title: 'text-purple-200',
 			icon: 'text-purple-400',
+		},
+		sky: {
+			border: 'border-sky-500/30',
+			title: 'text-sky-200',
+			icon: 'text-sky-400',
 		},
 	};
 
@@ -100,6 +106,19 @@ export const CastSettingsPanel = ({ service, accentColor }: CastSettingsPanelPro
 				if (adApiKey) {
 					await updateAllDebridSizeLimits(
 						adApiKey,
+						movieSize !== undefined ? Number(movieSize) : undefined,
+						episodeSize !== undefined ? Number(episodeSize) : undefined,
+						streamsLimit !== undefined ? Number(streamsLimit) : undefined,
+						hideCast
+					);
+				}
+			} else if (service === 'tr') {
+				const trBaseUrl = getLocalStorageString('torrin:baseUrl');
+				const trApiKey = getLocalStorageString('torrin:apiKey');
+				if (trBaseUrl && trApiKey) {
+					await updateTorrinSizeLimits(
+						trBaseUrl,
+						trApiKey,
 						movieSize !== undefined ? Number(movieSize) : undefined,
 						episodeSize !== undefined ? Number(episodeSize) : undefined,
 						streamsLimit !== undefined ? Number(streamsLimit) : undefined,

--- a/src/components/FloatingLibraryIndicator.test.tsx
+++ b/src/components/FloatingLibraryIndicator.test.tsx
@@ -7,6 +7,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: vi.fn(),
 	useAllDebridApiKey: vi.fn(),
 	useTorBoxAccessToken: vi.fn(),
+	useTorrinCreds: vi.fn(() => [null, null]),
 }));
 
 vi.mock('@/contexts/LibraryCacheContext', () => ({

--- a/src/components/FloatingLibraryIndicator.tsx
+++ b/src/components/FloatingLibraryIndicator.tsx
@@ -1,5 +1,10 @@
 import { useLibraryCache } from '@/contexts/LibraryCacheContext';
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { useRelativeTimeLabel } from '@/hooks/useRelativeTimeLabel';
 import { AlertCircle, RefreshCw } from 'lucide-react';
 import Link from 'next/link';
@@ -13,6 +18,7 @@ export default function FloatingLibraryIndicator() {
 	const [rdToken] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
 	const [mounted, setMounted] = useState(false);
 	const [isLoggedIn, setIsLoggedIn] = useState(false);
 	const lastFetchLabel = useRelativeTimeLabel(lastFetchTime, 'Just now');
@@ -23,8 +29,14 @@ export default function FloatingLibraryIndicator() {
 		const hasRd = localStorage.getItem('rd:accessToken');
 		const hasAd = localStorage.getItem('ad:apiKey');
 		const hasTb = localStorage.getItem('tb:apiKey');
+		const hasTr = localStorage.getItem('torrin:apiKey');
 		// Only return true if at least one key exists and is not empty
-		return !!(hasRd && hasRd.trim()) || !!(hasAd && hasAd.trim()) || !!(hasTb && hasTb.trim());
+		return (
+			!!(hasRd && hasRd.trim()) ||
+			!!(hasAd && hasAd.trim()) ||
+			!!(hasTb && hasTb.trim()) ||
+			!!(hasTr && hasTr.trim())
+		);
 	}, []);
 
 	// Handle client-side mounting to avoid hydration mismatch
@@ -39,7 +51,10 @@ export default function FloatingLibraryIndicator() {
 			// Check if any auth-related keys were added or removed
 			if (
 				e.key &&
-				(e.key.startsWith('rd:') || e.key.startsWith('ad:') || e.key.startsWith('tb:'))
+				(e.key.startsWith('rd:') ||
+					e.key.startsWith('ad:') ||
+					e.key.startsWith('tb:') ||
+					e.key.startsWith('torrin:'))
 			) {
 				setIsLoggedIn(checkAuthStatus());
 			}
@@ -67,9 +82,12 @@ export default function FloatingLibraryIndicator() {
 	// Sync with auth hooks when they change - use hooks as source of truth
 	useEffect(() => {
 		const hasValidAuth =
-			!!(rdToken && rdToken.trim()) || !!(adKey && adKey.trim()) || !!(tbKey && tbKey.trim());
+			!!(rdToken && rdToken.trim()) ||
+			!!(adKey && adKey.trim()) ||
+			!!(tbKey && tbKey.trim()) ||
+			!!(torrinBaseUrl && torrinBaseUrl.trim() && torrinApiKey && torrinApiKey.trim());
 		setIsLoggedIn(hasValidAuth);
-	}, [rdToken, adKey, tbKey]);
+	}, [rdToken, adKey, tbKey, torrinBaseUrl, torrinApiKey]);
 
 	const handleRefresh = async () => {
 		await refreshLibrary();

--- a/src/components/FloatingLibraryIndicator.tsx
+++ b/src/components/FloatingLibraryIndicator.tsx
@@ -30,12 +30,13 @@ export default function FloatingLibraryIndicator() {
 		const hasAd = localStorage.getItem('ad:apiKey');
 		const hasTb = localStorage.getItem('tb:apiKey');
 		const hasTr = localStorage.getItem('torrin:apiKey');
+		const hasTrBaseUrl = localStorage.getItem('torrin:baseUrl');
 		// Only return true if at least one key exists and is not empty
 		return (
 			!!(hasRd && hasRd.trim()) ||
 			!!(hasAd && hasAd.trim()) ||
 			!!(hasTb && hasTb.trim()) ||
-			!!(hasTr && hasTr.trim())
+			!!(hasTr && hasTr.trim() && hasTrBaseUrl && hasTrBaseUrl.trim())
 		);
 	}, []);
 

--- a/src/components/LibraryActionButtons.tsx
+++ b/src/components/LibraryActionButtons.tsx
@@ -17,6 +17,7 @@ interface LibraryActionButtonsProps {
 	rdKey: string | null;
 	adKey: string | null;
 	tbKey?: string | null;
+	trKey?: string | null;
 	showDedupe: boolean;
 	showHashCombine: boolean;
 }
@@ -37,6 +38,7 @@ export default function LibraryActionButtons({
 	rdKey,
 	adKey,
 	tbKey,
+	trKey,
 	showDedupe,
 	showHashCombine,
 }: LibraryActionButtonsProps) {
@@ -104,6 +106,13 @@ export default function LibraryActionButtons({
 						TB Restore
 					</LibraryButton>
 				</>
+			)}
+
+			{trKey && (
+				<LibraryButton variant="teal" onClick={() => onAddMagnet('tr')}>
+					<Link2 className="mr-1 inline-block h-4 w-4 text-teal-500" />
+					TR&nbsp;Add
+				</LibraryButton>
 			)}
 
 			<LibraryButton variant="indigo" onClick={onLocalBackup}>

--- a/src/components/LibraryMenuButtons.tsx
+++ b/src/components/LibraryMenuButtons.tsx
@@ -33,6 +33,7 @@ interface LibraryMenuButtonsProps {
 	hasRd?: boolean;
 	hasAd?: boolean;
 	hasTb?: boolean;
+	hasTr?: boolean;
 }
 
 export default function LibraryMenuButtons({
@@ -57,10 +58,11 @@ export default function LibraryMenuButtons({
 	hasRd,
 	hasAd,
 	hasTb,
+	hasTr,
 }: LibraryMenuButtonsProps) {
 	const hasActiveFilter =
 		!!activeMediaType || !!activeStatus || !!activeService || !!searchQuery || !!hasUrlFilter;
-	const multipleServices = [hasRd, hasAd, hasTb].filter(Boolean).length > 1;
+	const multipleServices = [hasRd, hasAd, hasTb, hasTr].filter(Boolean).length > 1;
 
 	const buildHref = (params: Record<string, string | undefined>) => {
 		const base: Record<string, string> = { page: '1' };
@@ -149,6 +151,16 @@ export default function LibraryMenuButtons({
 					active={activeService === 'tb'}
 				>
 					TB
+				</LibraryLinkButton>
+			)}
+			{multipleServices && hasTr && (
+				<LibraryLinkButton
+					href={buildHref({ service: 'tr' })}
+					deactivateHref={buildHref({ service: undefined })}
+					variant="green"
+					active={activeService === 'tr'}
+				>
+					TR
 				</LibraryLinkButton>
 			)}
 			{sameHashSize > 0 && (

--- a/src/components/LibraryTorrentRow.tsx
+++ b/src/components/LibraryTorrentRow.tsx
@@ -10,6 +10,7 @@ import {
 	handleDeleteAdTorrent,
 	handleDeleteRdTorrent,
 	handleDeleteTbTorrent,
+	handleDeleteTrTorrent,
 } from '@/utils/deleteTorrent';
 import { handleShare } from '@/utils/hashList';
 import { normalize } from '@/utils/mediaId';
@@ -43,6 +44,8 @@ interface TorrentRowProps {
 	rdKey: string | null;
 	adKey: string | null;
 	tbKey: string | null;
+	torrinBaseUrl?: string | null;
+	torrinApiKey?: string | null;
 	shouldDownloadMagnets: boolean;
 	hashGrouping: Record<string, number>;
 	titleGrouping: Record<string, number>;
@@ -63,6 +66,8 @@ function TorrentRow({
 	rdKey,
 	adKey,
 	tbKey,
+	torrinBaseUrl,
+	torrinApiKey,
 	shouldDownloadMagnets,
 	hashGrouping,
 	titleGrouping,
@@ -94,7 +99,7 @@ function TorrentRow({
 		return torrent.serviceStatus; // Fallback to raw status
 	};
 
-	const [castService, setCastService] = useState<'rd' | 'ad' | 'tb' | null>(null);
+	const [castService, setCastService] = useState<'rd' | 'ad' | 'tb' | 'tr' | null>(null);
 
 	// Handler for cast button click
 	const handleCastClick = async (imdbId?: string) => {
@@ -187,6 +192,36 @@ function TorrentRow({
 		}
 	};
 
+	const handleTrCastClick = async (imdbId?: string) => {
+		if (!torrinBaseUrl || !torrinApiKey || !torrent.id.startsWith('tr:')) return;
+
+		const trId = torrent.id.substring(3);
+		if (!trId || !torrent.hash) return;
+
+		setCastService('tr');
+		setIsCasting(true);
+		try {
+			const castUrl = `/api/stremio-tr/cast/library/${trId}:${torrent.hash}?baseUrl=${encodeURIComponent(torrinBaseUrl)}&apiKey=${encodeURIComponent(torrinApiKey)}${imdbId ? `&imdbId=${imdbId}` : ''}`;
+			const response = await fetch(castUrl);
+			const data = await response.json();
+
+			if (data.status === 'need_imdb_id') {
+				setCastTorrentInfo(data.torrentInfo);
+				setShowCastModal(true);
+			} else if (data.status === 'error') {
+				toast.error(data.errorMessage || 'Failed to cast to Stremio');
+			} else if (data.status === 'success') {
+				window.location.href = data.redirectUrl;
+				toast.success('Opening in Stremio...');
+			}
+		} catch (error) {
+			console.error('Cast error:', error);
+			toast.error('Failed to cast to Stremio');
+		} finally {
+			setIsCasting(false);
+		}
+	};
+
 	// Handler for IMDB ID selection from modal
 	const handleSelectImdbId = async (imdbId: string) => {
 		setShowCastModal(false);
@@ -194,6 +229,8 @@ function TorrentRow({
 			await handleTbCastClick(imdbId);
 		} else if (castService === 'ad') {
 			await handleAdCastClick(imdbId);
+		} else if (castService === 'tr') {
+			await handleTrCastClick(imdbId);
 		} else {
 			await handleCastClick(imdbId);
 		}
@@ -377,6 +414,19 @@ function TorrentRow({
 							<Cast className="h-4 w-4 text-cyan-400" />
 						</button>
 					)}
+					{torrinBaseUrl && torrinApiKey && torrent.id.startsWith('tr:') && (
+						<button
+							title="Cast (TR)"
+							className="mb-2 mr-2 cursor-pointer text-sky-400 disabled:opacity-50"
+							onClick={(e) => {
+								e.stopPropagation();
+								handleTrCastClick();
+							}}
+							disabled={isCasting}
+						>
+							<Cast className="h-4 w-4 text-sky-400" />
+						</button>
+					)}
 					<button
 						title="Share"
 						className="mb-2 mr-2 cursor-pointer text-indigo-600"
@@ -401,6 +451,13 @@ function TorrentRow({
 							}
 							if (tbKey && torrent.id.startsWith('tb:')) {
 								success = await handleDeleteTbTorrent(tbKey, torrent.id);
+							}
+							if (torrinBaseUrl && torrinApiKey && torrent.id.startsWith('tr:')) {
+								success = await handleDeleteTrTorrent(
+									torrinBaseUrl,
+									torrinApiKey,
+									torrent.id
+								);
 							}
 							if (success) onDelete(torrent.id);
 						}}

--- a/src/components/MainActions.tsx
+++ b/src/components/MainActions.tsx
@@ -7,12 +7,19 @@ interface MainActionsProps {
 	rdUser: RealDebridUser | null;
 	tbUser: TorBoxUser | null;
 	adUser: boolean;
+	torrinConnected?: boolean;
 	isLoading: boolean;
 }
 
 const isLocalDev = process.env.NODE_ENV === 'development';
 
-export function MainActions({ rdUser, tbUser, adUser, isLoading }: MainActionsProps) {
+export function MainActions({
+	rdUser,
+	tbUser,
+	adUser,
+	torrinConnected = false,
+	isLoading,
+}: MainActionsProps) {
 	const castButtons = [
 		rdUser && {
 			href: '/stremio',
@@ -40,6 +47,15 @@ export function MainActions({ rdUser, tbUser, adUser, isLoading }: MainActionsPr
 			hoverColor: 'hover:bg-yellow-800/50',
 			textColor: 'text-yellow-100',
 			iconColor: 'text-yellow-400',
+		},
+		torrinConnected && {
+			href: '/stremio-torrin',
+			label: 'Cast for TR',
+			borderColor: 'border-sky-500',
+			bgColor: 'bg-sky-900/30',
+			hoverColor: 'hover:bg-sky-800/50',
+			textColor: 'text-sky-100',
+			iconColor: 'text-sky-400',
 		},
 	].filter(Boolean) as {
 		href: string;

--- a/src/components/MovieSearchResults.tsx
+++ b/src/components/MovieSearchResults.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import ReportButton from './ReportButton';
+import TorrinResultButton from './TorrinResultButton';
 
 type MovieSearchResultsProps = {
 	filteredResults: SearchResult[];
@@ -28,6 +29,7 @@ type MovieSearchResultsProps = {
 	handleCast: (hash: string) => Promise<void>;
 	handleCastTorBox?: (hash: string) => Promise<void>;
 	handleCastAllDebrid?: (hash: string) => Promise<void>;
+	handleCastTorrin?: (hash: string) => Promise<void>;
 	handleCopyMagnet: (hash: string) => void;
 	checkServiceAvailability: (
 		result: SearchResult,
@@ -56,6 +58,7 @@ const MovieSearchResults = ({
 	handleCast,
 	handleCastTorBox,
 	handleCastAllDebrid,
+	handleCastTorrin,
 	handleCopyMagnet,
 	checkServiceAvailability,
 	addRd,
@@ -71,6 +74,7 @@ const MovieSearchResults = ({
 	const [castingHashes, setCastingHashes] = useState<Set<string>>(new Set());
 	const [castingTbHashes, setCastingTbHashes] = useState<Set<string>>(new Set());
 	const [castingAdHashes, setCastingAdHashes] = useState<Set<string>>(new Set());
+	const [castingTrHashes, setCastingTrHashes] = useState<Set<string>>(new Set());
 	const [downloadMagnets, setDownloadMagnets] = useState(false);
 
 	useEffect(() => {
@@ -213,6 +217,20 @@ const MovieSearchResults = ({
 		}
 	};
 
+	const handleCastTorrinWithLoading = async (hash: string) => {
+		if (!handleCastTorrin || castingTrHashes.has(hash)) return;
+		setCastingTrHashes((prev) => new Set(prev).add(hash));
+		try {
+			await handleCastTorrin(hash);
+		} finally {
+			setCastingTrHashes((prev) => {
+				const newSet = new Set(prev);
+				newSet.delete(hash);
+				return newSet;
+			});
+		}
+	};
+
 	const handleMagnetAction = (hash: string) => {
 		if (downloadMagnets) {
 			downloadMagnetFile(hash);
@@ -275,6 +293,7 @@ const MovieSearchResults = ({
 				const isCasting = castingHashes.has(r.hash);
 				const isCastingTb = castingTbHashes.has(r.hash);
 				const isCastingAd = castingAdHashes.has(r.hash);
+				const isCastingTr = castingTrHashes.has(r.hash);
 				const isCheckingRd = isHashServiceChecking(r.hash, 'RD');
 				const isCheckingAd = isHashServiceChecking(r.hash, 'AD');
 
@@ -450,6 +469,8 @@ const MovieSearchResults = ({
 									</button>
 								)}
 
+								<TorrinResultButton hash={r.hash} available={r.torrinAvailable} />
+
 								{/* Cast (RD) btn - only show if cached on RD */}
 								{rdKey && r.rdAvailable && (
 									<button
@@ -508,6 +529,27 @@ const MovieSearchResults = ({
 											<span className="inline-flex items-center">
 												<Cast className="mr-1 h-3 w-3 text-yellow-400" />
 												Cast (AD)
+											</span>
+										)}
+									</button>
+								)}
+
+								{/* Cast (TR) btn - only show if cached on Torrin */}
+								{handleCastTorrin && r.torrinAvailable && (
+									<button
+										className={`haptic-sm inline rounded border-2 border-sky-500 bg-sky-900/30 px-1 text-xs text-sky-100 transition-colors hover:bg-sky-800/50 ${isCastingTr ? 'cursor-not-allowed opacity-50' : ''}`}
+										onClick={() => handleCastTorrinWithLoading(r.hash)}
+										disabled={isCastingTr}
+									>
+										{isCastingTr ? (
+											<>
+												<Loader2 className="mr-1 inline-block h-3 w-3 animate-spin" />
+												Casting...
+											</>
+										) : (
+											<span className="inline-flex items-center">
+												<Cast className="mr-1 h-3 w-3 text-sky-400" />
+												Cast (TR)
 											</span>
 										)}
 									</button>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -1,6 +1,7 @@
 import { AllDebridUser, RealDebridUser } from '@/hooks/auth';
 import { TraktUser } from '@/services/trakt';
 import { TorBoxUser } from '@/services/types';
+import { escapeHtml } from '@/utils/torrinInfo';
 import { Check, X } from 'lucide-react';
 import Modal from '../components/modals/modal';
 
@@ -110,8 +111,8 @@ export function ServiceCard({ service, user, onTraktLogin, onLogout }: ServiceCa
 			prefix = 'torrin:';
 			html = `
         <div class="text-left">
-          <p><strong>Username:</strong> ${trUser.username ?? 'N/A'}</p>
-          <p><strong>Email:</strong> ${trUser.email ?? 'N/A'}</p>
+          <p><strong>Username:</strong> ${escapeHtml(trUser.username ?? 'N/A')}</p>
+          <p><strong>Email:</strong> ${escapeHtml(trUser.email ?? 'N/A')}</p>
           <p><strong>Premium:</strong> ${trUser.premium ? 'Yes' : 'No'}</p>
           ${trUser.expiration ? `<p><strong>Expires:</strong> ${new Date(trUser.expiration).toLocaleDateString()}</p>` : ''}
         </div>

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -5,7 +5,7 @@ import { Check, X } from 'lucide-react';
 import Modal from '../components/modals/modal';
 
 interface ServiceCardProps {
-	service: 'rd' | 'ad' | 'tb' | 'trakt';
+	service: 'rd' | 'ad' | 'tb' | 'trakt' | 'tr';
 	user: RealDebridUser | AllDebridUser | TraktUser | any | null;
 	onTraktLogin: () => void;
 	onLogout: (prefix: string) => void;
@@ -97,6 +97,23 @@ export function ServiceCard({ service, user, onTraktLogin, onLogout }: ServiceCa
           <p><strong>Joined:</strong> ${new Date(traktUser.user.joined_at).toLocaleDateString()}</p>
           <p><strong>Private:</strong> ${traktUser.user.private ? 'Yes' : 'No'}</p>
           <p><strong>VIP:</strong> ${traktUser.user.vip ? 'Yes' : 'No'}</p>
+        </div>
+      `;
+		} else if (service === 'tr' && user) {
+			const trUser = user as {
+				username?: string;
+				email?: string;
+				premium?: number;
+				expiration?: string;
+			};
+			title = 'Torrin';
+			prefix = 'torrin:';
+			html = `
+        <div class="text-left">
+          <p><strong>Username:</strong> ${trUser.username ?? 'N/A'}</p>
+          <p><strong>Email:</strong> ${trUser.email ?? 'N/A'}</p>
+          <p><strong>Premium:</strong> ${trUser.premium ? 'Yes' : 'No'}</p>
+          ${trUser.expiration ? `<p><strong>Expires:</strong> ${new Date(trUser.expiration).toLocaleDateString()}</p>` : ''}
         </div>
       `;
 		}
@@ -227,6 +244,28 @@ export function ServiceCard({ service, user, onTraktLogin, onLogout }: ServiceCa
 				className="haptic w-full rounded border-2 border-red-500 bg-red-900/30 py-1 text-center text-red-100 transition-colors hover:bg-red-800/50"
 			>
 				Trakt Login
+			</button>
+		);
+	}
+
+	if (service === 'tr') {
+		const trUser = user as { username?: string; email?: string } | null;
+		return trUser ? (
+			<button
+				onClick={() => showUserInfo('tr')}
+				className="haptic flex items-center justify-center gap-2 rounded border-2 border-sky-500 bg-sky-900/30 p-1 text-sky-100 transition-colors hover:bg-sky-800/50"
+			>
+				<span className="font-medium">Torrin</span>
+				<span>{(trUser.username || trUser.email || '').split('@')[0]}</span>
+				<Check className="h-4 w-4 text-green-500" />
+			</button>
+		) : (
+			<button
+				type="button"
+				onClick={onTraktLogin}
+				className="haptic w-full rounded border-2 border-sky-500 bg-sky-900/30 py-1 text-center text-sky-100 transition-colors hover:bg-sky-800/50"
+			>
+				Connect Torrin
 			</button>
 		);
 	}

--- a/src/components/SettingsSection.tsx
+++ b/src/components/SettingsSection.tsx
@@ -22,6 +22,7 @@ import {
 	defaultTorrentsFilter,
 } from '../utils/settings';
 import { updateTorBoxSizeLimits } from '../utils/torboxCastApiClient';
+import { updateTorrinSizeLimits } from '../utils/torrinCastApiClient';
 
 export const SettingsSection = () => {
 	const [isMagnetHandlerEnabled, setIsMagnetHandlerEnabled] = useState(() =>
@@ -187,6 +188,22 @@ export const SettingsSection = () => {
 			updatePromises.push(
 				updateAllDebridSizeLimits(
 					adApiKey,
+					movieSize !== undefined ? Number(movieSize) : undefined,
+					episodeSize !== undefined ? Number(episodeSize) : undefined,
+					streamsLimit !== undefined ? Number(streamsLimit) : undefined,
+					hideCast
+				)
+			);
+		}
+
+		// Update Torrin cast settings
+		const trBaseUrl = getLocalStorageString('torrin:baseUrl');
+		const trApiKey = getLocalStorageString('torrin:apiKey');
+		if (trBaseUrl && trApiKey) {
+			updatePromises.push(
+				updateTorrinSizeLimits(
+					trBaseUrl,
+					trApiKey,
 					movieSize !== undefined ? Number(movieSize) : undefined,
 					episodeSize !== undefined ? Number(episodeSize) : undefined,
 					streamsLimit !== undefined ? Number(streamsLimit) : undefined,

--- a/src/components/TorrinResultButton.tsx
+++ b/src/components/TorrinResultButton.tsx
@@ -1,0 +1,55 @@
+import useLocalStorage from '@/hooks/localStorage';
+import { addTorrinMagnet, selectTorrinFiles } from '@/services/torrin';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+
+export default function TorrinResultButton({
+	hash,
+	available,
+}: {
+	hash: string;
+	available?: boolean;
+}) {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	const [loading, setLoading] = useState(false);
+	const [added, setAdded] = useState(false);
+
+	if (!baseUrl || !apiKey) return null;
+
+	const isReady = available || added;
+	const cls = isReady
+		? 'border-green-500 bg-green-900/30 text-green-100 hover:bg-green-800/50'
+		: 'border-blue-500 bg-blue-900/30 text-blue-100 hover:bg-blue-800/50';
+
+	const add = async () => {
+		setLoading(true);
+		try {
+			const id = await addTorrinMagnet(baseUrl, apiKey, hash);
+			await selectTorrinFiles(baseUrl, apiKey, id, 'all');
+			setAdded(true);
+			toast.success('Added to Torrin');
+		} catch (e: any) {
+			toast.error(`Torrin: ${e?.message ?? 'failed to add'}`);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	return (
+		<button
+			className={`haptic-sm inline rounded border-2 px-1 text-xs transition-colors ${cls} ${loading ? 'cursor-not-allowed opacity-50' : ''}`}
+			onClick={add}
+			disabled={loading || isReady}
+		>
+			{loading ? (
+				<Loader2 className="inline-block h-3 w-3 animate-spin" />
+			) : isReady ? (
+				'TR ✓'
+			) : (
+				'Add TR'
+			)}
+		</button>
+	);
+}

--- a/src/components/TvSearchResults.tsx
+++ b/src/components/TvSearchResults.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import ReportButton from './ReportButton';
+import TorrinResultButton from './TorrinResultButton';
 
 type TvSearchResultsProps = {
 	filteredResults: SearchResult[];
@@ -29,6 +30,7 @@ type TvSearchResultsProps = {
 	handleCast: (hash: string, fileIds: string[]) => Promise<void>;
 	handleCastTorBox?: (hash: string, fileIds: string[]) => Promise<void>;
 	handleCastAllDebrid?: (hash: string, files: { filename: string }[]) => Promise<void>;
+	handleCastTorrin?: (hash: string, fileIds: string[]) => Promise<void>;
 	handleCopyMagnet: (hash: string) => void;
 	checkServiceAvailability: (
 		result: SearchResult,
@@ -58,6 +60,7 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 	handleCast,
 	handleCastTorBox,
 	handleCastAllDebrid,
+	handleCastTorrin,
 	handleCopyMagnet,
 	checkServiceAvailability,
 	addRd,
@@ -73,6 +76,7 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 	const [castingHashes, setCastingHashes] = useState<Set<string>>(new Set());
 	const [castingTbHashes, setCastingTbHashes] = useState<Set<string>>(new Set());
 	const [castingAdHashes, setCastingAdHashes] = useState<Set<string>>(new Set());
+	const [castingTrHashes, setCastingTrHashes] = useState<Set<string>>(new Set());
 	const [downloadMagnets, setDownloadMagnets] = useState(false);
 
 	useEffect(() => {
@@ -187,6 +191,20 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 		}
 	};
 
+	const handleCastTorrinWithLoading = async (hash: string, fileIds: string[]) => {
+		if (!handleCastTorrin || castingTrHashes.has(hash)) return;
+		setCastingTrHashes((prev) => new Set(prev).add(hash));
+		try {
+			await handleCastTorrin(hash, fileIds);
+		} finally {
+			setCastingTrHashes((prev) => {
+				const newSet = new Set(prev);
+				newSet.delete(hash);
+				return newSet;
+			});
+		}
+	};
+
 	const handleMagnetAction = (hash: string) => {
 		if (downloadMagnets) {
 			downloadMagnetFile(hash);
@@ -264,6 +282,7 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 						const isCasting = castingHashes.has(r.hash);
 						const isCastingTb = castingTbHashes.has(r.hash);
 						const isCastingAd = castingAdHashes.has(r.hash);
+						const isCastingTr = castingTrHashes.has(r.hash);
 						const isCheckingRd = isHashServiceChecking(r.hash, 'RD');
 						const isCheckingAd = isHashServiceChecking(r.hash, 'AD');
 
@@ -439,6 +458,11 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 											</button>
 										)}
 
+										<TorrinResultButton
+											hash={r.hash}
+											available={r.torrinAvailable}
+										/>
+
 										{/* Cast (RD) button - only show if cached on RD */}
 										{rdKey && r.rdAvailable && castableFileIds.length > 0 && (
 											<button
@@ -515,6 +539,34 @@ const TvSearchResults: React.FC<TvSearchResultsProps> = ({
 														<>
 															<Cast className="mr-1 inline-block h-3 w-3 text-yellow-400" />
 															Cast (AD)
+														</>
+													)}
+												</button>
+											)}
+
+										{/* Cast (TR) button - only show if cached on Torrin */}
+										{handleCastTorrin &&
+											r.torrinAvailable &&
+											castableFileIds.length > 0 && (
+												<button
+													className={`haptic-sm inline rounded border-2 border-sky-500 bg-sky-900/30 px-1 text-xs text-sky-100 transition-colors hover:bg-sky-800/50 ${isCastingTr ? 'cursor-not-allowed opacity-50' : ''}`}
+													onClick={() =>
+														handleCastTorrinWithLoading(
+															r.hash,
+															castableFileIds
+														)
+													}
+													disabled={isCastingTr}
+												>
+													{isCastingTr ? (
+														<>
+															<Loader2 className="mr-1 inline-block h-3 w-3 animate-spin" />
+															Casting...
+														</>
+													) : (
+														<>
+															<Cast className="mr-1 inline-block h-3 w-3 text-sky-400" />
+															Cast (TR)
 														</>
 													)}
 												</button>

--- a/src/contexts/EnhancedLibraryCacheContext.test.tsx
+++ b/src/contexts/EnhancedLibraryCacheContext.test.tsx
@@ -2,7 +2,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { UserTorrent, UserTorrentStatus } from '@/torrent/userTorrent';
 import {
 	EnhancedLibraryCacheProvider,
@@ -108,6 +113,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: vi.fn(),
 	useAllDebridApiKey: vi.fn(),
 	useTorBoxAccessToken: vi.fn(),
+	useTorrinCreds: vi.fn(),
 }));
 
 const wrapper = ({ children }: { children: ReactNode }) => (
@@ -117,6 +123,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 const mockedUseRealDebridAccessToken = vi.mocked(useRealDebridAccessToken);
 const mockedUseAllDebridApiKey = vi.mocked(useAllDebridApiKey);
 const mockedUseTorBoxAccessToken = vi.mocked(useTorBoxAccessToken);
+const mockedUseTorrinCreds = vi.mocked(useTorrinCreds);
 
 describe('EnhancedLibraryCacheContext refreshLibrary', () => {
 	beforeEach(() => {
@@ -130,6 +137,7 @@ describe('EnhancedLibraryCacheContext refreshLibrary', () => {
 		mockedUseRealDebridAccessToken.mockReturnValue([null, false, false]);
 		mockedUseAllDebridApiKey.mockReturnValue(null);
 		mockedUseTorBoxAccessToken.mockReturnValue(null);
+		mockedUseTorrinCreds.mockReturnValue([null, null]);
 	});
 
 	afterEach(() => {});

--- a/src/contexts/EnhancedLibraryCacheContext.tsx
+++ b/src/contexts/EnhancedLibraryCacheContext.tsx
@@ -4,12 +4,18 @@
  * parallel fetching, and automatic state monitoring
  */
 
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { CacheManager, getGlobalCache } from '@/services/cache/CacheManager';
 import { FetchOptions, UnifiedLibraryFetcher } from '@/services/library/UnifiedLibraryFetcher';
 import { UnifiedRateLimiter, getGlobalRateLimiter } from '@/services/rateLimit/UnifiedRateLimiter';
 import UserTorrentDB from '@/torrent/db';
 import { UserTorrent } from '@/torrent/userTorrent';
+import { packTorrinToken } from '@/utils/torrinToken';
 import {
 	ReactNode,
 	createContext,
@@ -69,6 +75,7 @@ interface LibraryStats {
 	rdItems: number;
 	adItems: number;
 	tbItems: number;
+	trItems: number;
 	lastSync: Date | null;
 	cacheHitRate: number;
 	averageFetchTime: number;
@@ -89,6 +96,7 @@ interface EnhancedLibraryCacheContextType {
 	rdLibrary: UserTorrent[];
 	adLibrary: UserTorrent[];
 	tbLibrary: UserTorrent[];
+	trLibrary: UserTorrent[];
 
 	// Status and stats
 	syncStatus: SyncStatus;
@@ -96,7 +104,7 @@ interface EnhancedLibraryCacheContextType {
 
 	// Actions
 	refreshLibrary: (
-		service?: 'realdebrid' | 'alldebrid' | 'torbox',
+		service?: 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin',
 		force?: boolean
 	) => Promise<void>;
 	refreshAll: (force?: boolean) => Promise<void>;
@@ -135,15 +143,19 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 	const [rdKey, rdLoading] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
+	const trKey =
+		torrinBaseUrl && torrinApiKey ? packTorrinToken(torrinBaseUrl, torrinApiKey) : null;
 
 	// Library state
 	const [libraryItems, setLibraryItems] = useState<UserTorrent[]>([]);
 	const [rdLibrary, setRdLibrary] = useState<UserTorrent[]>([]);
 	const [adLibrary, setAdLibrary] = useState<UserTorrent[]>([]);
 	const [tbLibrary, setTbLibrary] = useState<UserTorrent[]>([]);
+	const [trLibrary, setTrLibrary] = useState<UserTorrent[]>([]);
 
 	// Auth state helper
-	const hasAnyAuth = Boolean(rdKey || adKey || tbKey);
+	const hasAnyAuth = Boolean(rdKey || adKey || tbKey || trKey);
 
 	// Sync status
 	const [syncStatus, setSyncStatus] = useState<SyncStatus>({
@@ -161,6 +173,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		rdItems: 0,
 		adItems: 0,
 		tbItems: 0,
+		trItems: 0,
 		lastSync: null,
 		cacheHitRate: 0,
 		averageFetchTime: 0,
@@ -176,11 +189,13 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		rd: normalizeToken(rdKey),
 		ad: normalizeToken(adKey),
 		tb: normalizeToken(tbKey),
+		tr: normalizeToken(trKey),
 	});
 	const initialRefreshDoneRef = useRef({
 		rd: false,
 		ad: false,
 		tb: false,
+		tr: false,
 	});
 
 	// Update statistics
@@ -188,6 +203,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		const rd = torrents.filter((t) => t.id.startsWith('rd:')).length;
 		const ad = torrents.filter((t) => t.id.startsWith('ad:')).length;
 		const tb = torrents.filter((t) => t.id.startsWith('tb:')).length;
+		const tr = torrents.filter((t) => t.id.startsWith('tr:')).length;
 
 		const cacheHitRate =
 			cacheHitsRef.current.hits + cacheHitsRef.current.misses > 0
@@ -205,6 +221,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			rdItems: rd,
 			adItems: ad,
 			tbItems: tb,
+			trItems: tr,
 			lastSync: prev.lastSync,
 			cacheHitRate: Math.round(cacheHitRate * 100),
 			averageFetchTime: Math.round(avgFetchTime),
@@ -223,14 +240,17 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 				const rd = cachedTorrents.filter((t) => t.id.startsWith('rd:'));
 				const ad = cachedTorrents.filter((t) => t.id.startsWith('ad:'));
 				const tb = cachedTorrents.filter((t) => t.id.startsWith('tb:'));
+				const tr = cachedTorrents.filter((t) => t.id.startsWith('tr:'));
 
 				setRdLibrary(rd);
 				setAdLibrary(ad);
 				setTbLibrary(tb);
+				setTrLibrary(tr);
 
 				initialRefreshDoneRef.current.rd = rd.length > 0;
 				initialRefreshDoneRef.current.ad = ad.length > 0;
 				initialRefreshDoneRef.current.tb = tb.length > 0;
+				initialRefreshDoneRef.current.tr = tr.length > 0;
 
 				updateStats(cachedTorrents);
 
@@ -280,14 +300,20 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		}
 	}, [tbKey]);
 
+	useEffect(() => {
+		if (!trKey) {
+			setTrLibrary([]);
+		}
+	}, [trKey]);
+
 	// Update combined library
 	const updateCombinedLibrary = useCallback(() => {
-		const combined = [...rdLibrary, ...adLibrary, ...tbLibrary];
+		const combined = [...rdLibrary, ...adLibrary, ...tbLibrary, ...trLibrary];
 
 		const shouldLogAndPersist = hasAnyAuth || combined.length > 0;
 		if (shouldLogAndPersist) {
 			console.log(
-				`[LibraryCache] Updating combined library: RD:${rdLibrary.length}, AD:${adLibrary.length}, TB:${tbLibrary.length}, Total:${combined.length}`
+				`[LibraryCache] Updating combined library: RD:${rdLibrary.length}, AD:${adLibrary.length}, TB:${tbLibrary.length}, TR:${trLibrary.length}, Total:${combined.length}`
 			);
 		}
 
@@ -368,22 +394,26 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		}
 
 		updateStats(combined);
-	}, [rdLibrary, adLibrary, tbLibrary, updateStats, hasAnyAuth]);
+	}, [rdLibrary, adLibrary, tbLibrary, trLibrary, updateStats, hasAnyAuth]);
 
 	// Trigger combined library update when any service library changes
 	useEffect(() => {
 		updateCombinedLibrary();
-	}, [rdLibrary, adLibrary, tbLibrary, updateCombinedLibrary]);
+	}, [rdLibrary, adLibrary, tbLibrary, trLibrary, updateCombinedLibrary]);
 
 	// Refresh library for a specific service or all
 	const refreshLibrary = useCallback(
-		async (service?: 'realdebrid' | 'alldebrid' | 'torbox', force: boolean = false) => {
-			type Service = 'realdebrid' | 'alldebrid' | 'torbox';
+		async (
+			service?: 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin',
+			force: boolean = false
+		) => {
+			type Service = 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin';
 			const tokens: Record<Service, string | undefined> = {
 				realdebrid:
 					typeof rdKey === 'string' && rdKey.trim().length > 0 ? rdKey : undefined,
 				alldebrid: typeof adKey === 'string' && adKey.trim().length > 0 ? adKey : undefined,
 				torbox: typeof tbKey === 'string' && tbKey.trim().length > 0 ? tbKey : undefined,
+				torrin: typeof trKey === 'string' && trKey.trim().length > 0 ? trKey : undefined,
 			};
 
 			const runSingle = async (target: Service, token: string | undefined) => {
@@ -458,6 +488,9 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 						case 'torbox':
 							setTbLibrary(torrents);
 							break;
+						case 'torrin':
+							setTrLibrary(torrents);
+							break;
 					}
 
 					setStats((prev) => ({ ...prev, lastSync: syncCompletedAt }));
@@ -485,7 +518,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			};
 
 			if (!service) {
-				const services: Service[] = ['realdebrid', 'alldebrid', 'torbox'];
+				const services: Service[] = ['realdebrid', 'alldebrid', 'torbox', 'torrin'];
 				console.log('[LibraryCache] refreshLibrary multi-service start', {
 					force,
 					services,
@@ -510,7 +543,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			});
 			await runSingle(service, tokens[service]);
 		},
-		[rdKey, adKey, tbKey]
+		[rdKey, adKey, tbKey, trKey]
 	);
 
 	const refreshAll = useCallback(
@@ -522,7 +555,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 
 	const scheduleServiceRefresh = useCallback(
 		async (
-			target: 'realdebrid' | 'alldebrid' | 'torbox',
+			target: 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin',
 			reason: 'tokenChanged' | 'initialEmpty'
 		) => {
 			console.log('[LibraryCache] scheduling service refresh', { target, reason });
@@ -531,7 +564,13 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			} catch (error) {
 				console.error('[LibraryCache] Auto refresh failed', { target, error });
 				initialRefreshDoneRef.current[
-					target === 'realdebrid' ? 'rd' : target === 'alldebrid' ? 'ad' : 'tb'
+					target === 'realdebrid'
+						? 'rd'
+						: target === 'alldebrid'
+							? 'ad'
+							: target === 'torbox'
+								? 'tb'
+								: 'tr'
 				] = false;
 			}
 		},
@@ -675,6 +714,50 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		void scheduleServiceRefresh('torbox', tokenChanged ? 'tokenChanged' : 'initialEmpty');
 	}, [tbKey, tbLibrary.length, scheduleServiceRefresh, hasLoadedInitialData]);
 
+	useEffect(() => {
+		if (!hasLoadedInitialData) {
+			return;
+		}
+
+		const currentToken = normalizeToken(trKey);
+		const previousToken = previousTokenStateRef.current.tr;
+		const tokenChanged = currentToken !== previousToken;
+		logTokenTransition('Torrin', currentToken, previousToken, {
+			librarySize: trLibrary.length,
+			hasFetched: initialRefreshDoneRef.current.tr,
+		});
+
+		if (!currentToken) {
+			previousTokenStateRef.current.tr = null;
+			initialRefreshDoneRef.current.tr = false;
+			return;
+		}
+
+		if (tokenChanged) {
+			initialRefreshDoneRef.current.tr = false;
+		}
+
+		previousTokenStateRef.current.tr = currentToken;
+
+		const hasFetched = initialRefreshDoneRef.current.tr;
+		const shouldRefresh = tokenChanged || (!hasFetched && trLibrary.length === 0);
+
+		if (!shouldRefresh) {
+			console.log('[LibraryCache] Auto refresh skipped for Torrin', {
+				tokenChanged,
+				hasFetched,
+				librarySize: trLibrary.length,
+			});
+			return;
+		}
+
+		initialRefreshDoneRef.current.tr = true;
+		console.log('[LibraryCache] Auto refresh triggered for Torrin', {
+			reason: tokenChanged ? 'tokenChanged' : 'initialEmpty',
+		});
+		void scheduleServiceRefresh('torrin', tokenChanged ? 'tokenChanged' : 'initialEmpty');
+	}, [trKey, trLibrary.length, scheduleServiceRefresh, hasLoadedInitialData]);
+
 	// Clear cache
 	const clearCache = async (service?: string) => {
 		if (service) {
@@ -698,6 +781,8 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			setAdLibrary((prev) => upsertTorrentById(prev, torrent));
 		} else if (torrent.id.startsWith('tb:')) {
 			setTbLibrary((prev) => upsertTorrentById(prev, torrent));
+		} else if (torrent.id.startsWith('tr:')) {
+			setTrLibrary((prev) => upsertTorrentById(prev, torrent));
 		}
 	};
 
@@ -713,6 +798,8 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			setAdLibrary((prev) => prev.filter((t) => t.id !== torrentId));
 		} else if (torrentId.startsWith('tb:')) {
 			setTbLibrary((prev) => prev.filter((t) => t.id !== torrentId));
+		} else if (torrentId.startsWith('tr:')) {
+			setTrLibrary((prev) => prev.filter((t) => t.id !== torrentId));
 		}
 	};
 
@@ -725,6 +812,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		const rdIds = torrentIds.filter((id) => id.startsWith('rd:'));
 		const adIds = torrentIds.filter((id) => id.startsWith('ad:'));
 		const tbIds = torrentIds.filter((id) => id.startsWith('tb:'));
+		const trIds = torrentIds.filter((id) => id.startsWith('tr:'));
 		if (rdIds.length > 0) {
 			const rdSet = new Set(rdIds);
 			setRdLibrary((prev) => prev.filter((t) => !rdSet.has(t.id)));
@@ -736,6 +824,10 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		if (tbIds.length > 0) {
 			const tbSet = new Set(tbIds);
 			setTbLibrary((prev) => prev.filter((t) => !tbSet.has(t.id)));
+		}
+		if (trIds.length > 0) {
+			const trSet = new Set(trIds);
+			setTrLibrary((prev) => prev.filter((t) => !trSet.has(t.id)));
 		}
 	};
 
@@ -752,10 +844,14 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 			setAdLibrary(updateFn);
 		} else if (torrentId.startsWith('tb:')) {
 			setTbLibrary(updateFn);
+		} else if (torrentId.startsWith('tr:')) {
+			setTrLibrary(updateFn);
 		}
 
 		// Update in database
-		const torrent = [...rdLibrary, ...adLibrary, ...tbLibrary].find((t) => t.id === torrentId);
+		const torrent = [...rdLibrary, ...adLibrary, ...tbLibrary, ...trLibrary].find(
+			(t) => t.id === torrentId
+		);
 		if (torrent) {
 			// No explicit update method; re-add to replace existing
 			torrentDB.add({ ...torrent, ...updates });
@@ -767,6 +863,7 @@ export function EnhancedLibraryCacheProvider({ children }: { children: ReactNode
 		rdLibrary,
 		adLibrary,
 		tbLibrary,
+		trLibrary,
 		syncStatus,
 		stats,
 		refreshLibrary,

--- a/src/hooks/auth.ts
+++ b/src/hooks/auth.ts
@@ -3,7 +3,9 @@ import { useEffect, useState } from 'react';
 import { getAllDebridUser } from '../services/allDebrid';
 import { getCurrentUser as getRealDebridUser, getToken } from '../services/realDebrid';
 import { TorBoxUser, getUserData } from '../services/torbox';
+import { getTorrinUser } from '../services/torrin';
 import { TraktUser, getTraktUser } from '../services/trakt';
+import { UserResponse } from '../services/types';
 import { clearRdKeys } from '../utils/clearLocalStorage';
 import { getSafeRedirectPath } from '../utils/router';
 import useLocalStorage from './localStorage';
@@ -236,6 +238,34 @@ const useTorBox = () => {
 	return { user, error, hasAuth: !!token, loading };
 };
 
+const useTorrin = () => {
+	const [user, setUser] = useState<UserResponse | null>(null);
+	const [error, setError] = useState<Error | null>(null);
+	const [loading, setLoading] = useState(false);
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+
+	useEffect(() => {
+		if (!apiKey || !baseUrl) {
+			return;
+		}
+
+		setLoading(true);
+		getTorrinUser(baseUrl, apiKey)
+			.then((u) => {
+				setUser(u);
+				setError(null);
+				setLoading(false);
+			})
+			.catch((e) => {
+				setError(e as Error);
+				setLoading(false);
+			});
+	}, [apiKey, baseUrl]);
+
+	return { user, error, hasAuth: !!apiKey && !!baseUrl, loading };
+};
+
 const useTrakt = () => {
 	const [user, setUser] = useState<TraktUser | null>(null);
 	const [error, setError] = useState<Error | null>(null);
@@ -283,11 +313,18 @@ export const useTorBoxAccessToken = () => {
 	return apiKey;
 };
 
+export const useTorrinCreds = (): [string | null, string | null] => {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	return [baseUrl, apiKey];
+};
+
 // Main hook that combines all services
 export const useCurrentUser = () => {
 	const rd = useRealDebrid();
 	const ad = useAllDebrid();
 	const tb = useTorBox();
+	const torrin = useTorrin();
 	const trakt = useTrakt();
 
 	return {
@@ -301,6 +338,9 @@ export const useCurrentUser = () => {
 		tbUser: tb.user,
 		tbError: tb.error,
 		hasTBAuth: tb.hasAuth,
+		torrinUser: torrin.user,
+		torrinError: torrin.error,
+		hasTorrinAuth: torrin.hasAuth,
 		traktUser: trakt.user,
 		traktError: trakt.error,
 		hasTraktAuth: trakt.hasAuth,
@@ -332,5 +372,6 @@ export const useDebridLogin = () => {
 		loginWithRealDebrid: () => navigateToLogin('/realdebrid/login'),
 		loginWithAllDebrid: () => navigateToLogin('/alldebrid/login'),
 		loginWithTorbox: () => navigateToLogin('/torbox/login'),
+		loginWithTorrin: () => navigateToLogin('/torrin/login'),
 	};
 };

--- a/src/hooks/torrinCastToken.test.ts
+++ b/src/hooks/torrinCastToken.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTorrinCastToken } from './torrinCastToken';
+
+vi.mock('@/utils/torrinCastApiClient', () => ({
+	saveTorrinCastProfile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/utils/browserStorage', () => ({
+	getLocalStorageItemOrDefault: vi.fn().mockReturnValue('100'),
+	getLocalStorageBoolean: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/utils/settings', () => ({
+	defaultMovieSize: 2000,
+	defaultEpisodeSize: 1000,
+	defaultOtherStreamsLimit: 5,
+}));
+
+vi.mock('react-hot-toast', () => ({
+	default: {
+		error: vi.fn(),
+	},
+}));
+
+const localStorageMock = vi.fn().mockReturnValue([null, vi.fn()]);
+vi.mock('./localStorage', () => ({
+	default: (...args: any[]) => localStorageMock(...args),
+}));
+
+global.fetch = vi.fn();
+
+const withCreds =
+	(extra: Record<string, [any, any]> = {}) =>
+	(key: string) => {
+		if (extra[key]) return extra[key];
+		if (key === 'torrin:baseUrl') return ['https://tr.test', vi.fn()];
+		if (key === 'torrin:apiKey') return ['test-key', vi.fn()];
+		if (key === 'torrin:castToken') return [null, vi.fn()];
+		return [null, vi.fn()];
+	};
+
+describe('useTorrinCastToken', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorageMock.mockReturnValue([null, vi.fn()]);
+	});
+
+	it('returns null when creds are not set', () => {
+		const { result } = renderHook(() => useTorrinCastToken());
+		expect(result.current).toBeNull();
+	});
+
+	it('handles API errors gracefully', async () => {
+		localStorageMock.mockImplementation(withCreds());
+		global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+		const { result } = renderHook(() => useTorrinCastToken());
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(result.current).toBeNull();
+	});
+
+	it('skips fetch when token already exists', async () => {
+		localStorageMock.mockImplementation(
+			withCreds({ 'torrin:castToken': ['existing-token', vi.fn()] })
+		);
+
+		renderHook(() => useTorrinCastToken());
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	it('fetches token with baseUrl + apiKey when none exists', async () => {
+		localStorageMock.mockImplementation(withCreds());
+		global.fetch = vi.fn().mockResolvedValue({
+			json: () => Promise.resolve({ status: 'success', id: 'tr-token-456' }),
+		});
+
+		renderHook(() => useTorrinCastToken());
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(global.fetch).toHaveBeenCalledWith(
+			`/api/stremio-tr/id?baseUrl=${encodeURIComponent('https://tr.test')}&apiKey=test-key`
+		);
+	});
+
+	it('does not set token on error response', async () => {
+		const setToken = vi.fn();
+		localStorageMock.mockImplementation(withCreds({ 'torrin:castToken': [null, setToken] }));
+		global.fetch = vi.fn().mockResolvedValue({
+			json: () => Promise.resolve({ status: 'error', message: 'Bad key' }),
+		});
+
+		renderHook(() => useTorrinCastToken());
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		});
+
+		expect(setToken).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/torrinCastToken.ts
+++ b/src/hooks/torrinCastToken.ts
@@ -1,0 +1,57 @@
+import { getLocalStorageBoolean, getLocalStorageItemOrDefault } from '@/utils/browserStorage';
+import { defaultEpisodeSize, defaultMovieSize, defaultOtherStreamsLimit } from '@/utils/settings';
+import { saveTorrinCastProfile } from '@/utils/torrinCastApiClient';
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
+import useLocalStorage from './localStorage';
+
+export function useTorrinCastToken() {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	const [dmmCastToken, setDmmCastToken] = useLocalStorage<string>('torrin:castToken');
+
+	useEffect(() => {
+		if (!baseUrl || !apiKey) return;
+		if (dmmCastToken) return;
+
+		const fetchToken = async () => {
+			try {
+				const res = await fetch(
+					`/api/stremio-tr/id?baseUrl=${encodeURIComponent(baseUrl)}&apiKey=${encodeURIComponent(apiKey)}`
+				);
+				const data = await res.json();
+				if (data.status !== 'error' && data.id) {
+					const movieMaxSize = Number(
+						getLocalStorageItemOrDefault('settings:movieMaxSize', defaultMovieSize)
+					);
+					const episodeMaxSize = Number(
+						getLocalStorageItemOrDefault('settings:episodeMaxSize', defaultEpisodeSize)
+					);
+					const otherStreamsLimit = Number(
+						getLocalStorageItemOrDefault(
+							'settings:otherStreamsLimit',
+							defaultOtherStreamsLimit
+						)
+					);
+					const hideCastOption = getLocalStorageBoolean('settings:hideCastOption', false);
+					await saveTorrinCastProfile(
+						baseUrl,
+						apiKey,
+						movieMaxSize,
+						episodeMaxSize,
+						otherStreamsLimit,
+						hideCastOption
+					);
+					setDmmCastToken(data.id);
+				}
+			} catch (error) {
+				toast.error('Failed to fetch DMM Cast Torrin token.');
+			}
+		};
+
+		fetchToken();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [baseUrl, apiKey, dmmCastToken]);
+
+	return dmmCastToken;
+}

--- a/src/hooks/useExternalSources.ts
+++ b/src/hooks/useExternalSources.ts
@@ -6,9 +6,10 @@ import { useCallback, useEffect, useState } from 'react';
 export function useExternalSources(
 	rdKey: string | null,
 	adKey?: string | null,
-	tbKey?: string | null
+	tbKey?: string | null,
+	torrinApiKey?: string | null
 ) {
-	const hasAnyDebridKey = !!(rdKey || adKey || tbKey);
+	const hasAnyDebridKey = !!(rdKey || adKey || tbKey || torrinApiKey);
 	const [mediafusionHash, setMediafusionHash] = useState<string>('');
 
 	// Get or generate MediaFusion hash

--- a/src/hooks/useMassReport.ts
+++ b/src/hooks/useMassReport.ts
@@ -7,11 +7,12 @@ export function useMassReport(
 	rdKey: string | null,
 	adKey: string | null,
 	torboxKey: string | null,
-	imdbId: string
+	imdbId: string,
+	torrinApiKey?: string | null
 ) {
 	const handleMassReport = useCallback(
 		async (type: 'porn' | 'wrong_imdb' | 'wrong_season', filteredResults: SearchResult[]) => {
-			if (!rdKey && !adKey && !torboxKey) {
+			if (!rdKey && !adKey && !torboxKey && !torrinApiKey) {
 				toast.error('Sign in to a debrid service before reporting.');
 				return;
 			}
@@ -34,7 +35,7 @@ export function useMassReport(
 
 			try {
 				// Use the debrid key as userId
-				const userId = rdKey || adKey || torboxKey || '';
+				const userId = rdKey || adKey || torboxKey || torrinApiKey || '';
 
 				// Prepare reports data
 				const reports = filteredResults.map((result) => ({
@@ -74,7 +75,7 @@ export function useMassReport(
 				}, 1500);
 			}
 		},
-		[rdKey, adKey, torboxKey, imdbId]
+		[rdKey, adKey, torboxKey, imdbId, torrinApiKey]
 	);
 
 	return { handleMassReport };

--- a/src/hooks/useTorrinAvailability.ts
+++ b/src/hooks/useTorrinAvailability.ts
@@ -21,7 +21,11 @@ export function useTorrinAvailability(
 		torrinInstantCheck(baseUrl, apiKey, hashes)
 			.then((resp) => {
 				if (cancelled) return;
-				const cached = new Set(Object.keys(resp || {}).map((h) => h.toLowerCase()));
+				const cached = new Set(
+					Object.entries(resp || {})
+						.filter(([, v]) => ((v as any)?.rd?.length ?? 0) > 0)
+						.map(([h]) => h.toLowerCase())
+				);
 				if (cached.size === 0) return;
 				setSearchResults((prev) => {
 					let changed = false;

--- a/src/hooks/useTorrinAvailability.ts
+++ b/src/hooks/useTorrinAvailability.ts
@@ -17,6 +17,16 @@ export function useTorrinAvailability(
 		const hashes = hashKey.split(',').filter(Boolean);
 		if (hashes.length === 0) return;
 
-		processTrInstantCheck(baseUrl, apiKey, hashes, setSearchResults).catch(() => {});
+		// Ignore a late-finishing check once the base URL, key, or result set changes,
+		// so a stale request can't clobber the current results.
+		let cancelled = false;
+		const guardedSetter: React.Dispatch<React.SetStateAction<SearchResult[]>> = (update) => {
+			if (!cancelled) setSearchResults(update);
+		};
+		processTrInstantCheck(baseUrl, apiKey, hashes, guardedSetter).catch(() => {});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [baseUrl, apiKey, hashKey, setSearchResults]);
 }

--- a/src/hooks/useTorrinAvailability.ts
+++ b/src/hooks/useTorrinAvailability.ts
@@ -1,5 +1,5 @@
 import { SearchResult } from '@/services/mediasearch';
-import { torrinInstantCheck } from '@/services/torrin';
+import { processTrInstantCheck } from '@/utils/instantChecks';
 import { useEffect } from 'react';
 import useLocalStorage from './localStorage';
 
@@ -17,32 +17,6 @@ export function useTorrinAvailability(
 		const hashes = hashKey.split(',').filter(Boolean);
 		if (hashes.length === 0) return;
 
-		let cancelled = false;
-		torrinInstantCheck(baseUrl, apiKey, hashes)
-			.then((resp) => {
-				if (cancelled) return;
-				const cached = new Set(
-					Object.entries(resp || {})
-						.filter(([, v]) => ((v as any)?.rd?.length ?? 0) > 0)
-						.map(([h]) => h.toLowerCase())
-				);
-				if (cached.size === 0) return;
-				setSearchResults((prev) => {
-					let changed = false;
-					const next = prev.map((r) => {
-						if (cached.has(r.hash.toLowerCase()) && !r.torrinAvailable) {
-							changed = true;
-							return { ...r, torrinAvailable: true };
-						}
-						return r;
-					});
-					return changed ? next : prev;
-				});
-			})
-			.catch(() => {});
-
-		return () => {
-			cancelled = true;
-		};
+		processTrInstantCheck(baseUrl, apiKey, hashes, setSearchResults).catch(() => {});
 	}, [baseUrl, apiKey, hashKey, setSearchResults]);
 }

--- a/src/hooks/useTorrinAvailability.ts
+++ b/src/hooks/useTorrinAvailability.ts
@@ -1,0 +1,44 @@
+import { SearchResult } from '@/services/mediasearch';
+import { torrinInstantCheck } from '@/services/torrin';
+import { useEffect } from 'react';
+import useLocalStorage from './localStorage';
+
+export function useTorrinAvailability(
+	searchResults: SearchResult[],
+	setSearchResults: React.Dispatch<React.SetStateAction<SearchResult[]>>
+) {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+
+	const hashKey = searchResults.map((r) => r.hash).join(',');
+
+	useEffect(() => {
+		if (!baseUrl || !apiKey || !hashKey) return;
+		const hashes = hashKey.split(',').filter(Boolean);
+		if (hashes.length === 0) return;
+
+		let cancelled = false;
+		torrinInstantCheck(baseUrl, apiKey, hashes)
+			.then((resp) => {
+				if (cancelled) return;
+				const cached = new Set(Object.keys(resp || {}).map((h) => h.toLowerCase()));
+				if (cached.size === 0) return;
+				setSearchResults((prev) => {
+					let changed = false;
+					const next = prev.map((r) => {
+						if (cached.has(r.hash.toLowerCase()) && !r.torrinAvailable) {
+							changed = true;
+							return { ...r, torrinAvailable: true };
+						}
+						return r;
+					});
+					return changed ? next : prev;
+				});
+			})
+			.catch(() => {});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [baseUrl, apiKey, hashKey, setSearchResults]);
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -66,7 +66,13 @@ export default function App({ Component, pageProps }: AppWithProvidersProps) {
 			router.events.off('routeChangeComplete', handleRouteChangeComplete);
 		};
 	}, [router]);
-	const authRoutes = ['/start', '/realdebrid/login', '/alldebrid/login', '/torbox/login'];
+	const authRoutes = [
+		'/start',
+		'/realdebrid/login',
+		'/alldebrid/login',
+		'/torbox/login',
+		'/torrin/login',
+	];
 	const disableLibraryProvider =
 		authRoutes.includes(router.pathname) || Component.disableLibraryProvider === true;
 	const shouldWrapWithLibraryProvider = !disableLibraryProvider;

--- a/src/pages/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json.ts
+++ b/src/pages/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json.ts
@@ -1,0 +1,39 @@
+import { repository as db } from '@/services/repository';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	const { userid } = req.query;
+	if (typeof userid !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" query parameter',
+		});
+		return;
+	}
+
+	try {
+		const castedMovies = await db.fetchTorrinCastedMovies(userid);
+		const metas = castedMovies.map((movie) => ({
+			id: movie,
+			type: 'movie',
+			poster: `https://images.metahub.space/poster/small/${movie}/img`,
+		}));
+
+		res.status(200).json({
+			metas,
+			cacheMaxAge: 0,
+		});
+	} catch (error) {
+		console.error(
+			'Failed to get Torrin casted movies:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: 'Failed to get Torrin casted movies' });
+	}
+}

--- a/src/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json.ts
+++ b/src/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json.ts
@@ -1,0 +1,27 @@
+import { getTorrinDMMLibrary } from '@/utils/torrinCastCatalogHelper';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { userid } = req.query;
+	if (typeof userid !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" query parameter',
+		});
+		return;
+	}
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	const result = await getTorrinDMMLibrary(userid, 1);
+
+	if ('error' in result) {
+		return res.status(result.status).json({ error: result.error });
+	}
+
+	res.status(result.status).json(result.data);
+}

--- a/src/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip].ts
+++ b/src/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip].ts
@@ -1,0 +1,38 @@
+import { PAGE_SIZE, getTorrinDMMLibrary } from '@/utils/torrinCastCatalogHelper';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { userid, skip } = req.query;
+	if (typeof userid !== 'string' || typeof skip !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" or "skip" query parameter',
+		});
+		return;
+	}
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	const skipValue = parseInt(skip.replace('.json', '').replace('skip=', ''), 10);
+	if (isNaN(skipValue)) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "skip" value',
+		});
+		return;
+	}
+
+	const page = Math.floor(skipValue / PAGE_SIZE) + 1;
+
+	const result = await getTorrinDMMLibrary(userid, page);
+
+	if ('error' in result) {
+		return res.status(result.status).json({ error: result.error });
+	}
+
+	res.status(result.status).json(result.data);
+}

--- a/src/pages/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json.ts
+++ b/src/pages/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json.ts
@@ -1,0 +1,39 @@
+import { repository as db } from '@/services/repository';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	const { userid } = req.query;
+	if (typeof userid !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" query parameter',
+		});
+		return;
+	}
+
+	try {
+		const castedShows = await db.fetchTorrinCastedShows(userid);
+		const metas = castedShows.map((show) => ({
+			id: show,
+			type: 'series',
+			poster: `https://images.metahub.space/poster/small/${show}/img`,
+		}));
+
+		res.status(200).json({
+			metas,
+			cacheMaxAge: 0,
+		});
+	} catch (error) {
+		console.error(
+			'Failed to get Torrin casted shows:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: 'Failed to get Torrin casted shows' });
+	}
+}

--- a/src/pages/api/stremio-tr/[userid]/manifest.json.ts
+++ b/src/pages/api/stremio-tr/[userid]/manifest.json.ts
@@ -1,0 +1,46 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+	res.status(200).json({
+		id: 'com.debridmediamanager.cast.torrin',
+		name: 'DMM Cast for Torrin',
+		description:
+			'Cast your preferred Debrid Media Manager streams to your Stremio device using Torrin; supports Anime, TV shows and Movies!',
+		logo: 'https://static.debridmediamanager.com/dmmcast.png',
+		background: 'https://static.debridmediamanager.com/background.png',
+		version: '0.0.1',
+		resources: [
+			{
+				name: 'stream',
+				types: ['movie', 'series'],
+				idPrefixes: ['tt'],
+			},
+			{
+				name: 'meta',
+				types: ['other'],
+				idPrefixes: ['dmm-tr'],
+			},
+		],
+		types: ['movie', 'series', 'other'],
+		catalogs: [
+			{
+				id: 'tr-casted-movies',
+				name: 'DMM TR Movies',
+				type: 'movie',
+			},
+			{
+				id: 'tr-casted-shows',
+				name: 'DMM TR TV Shows',
+				type: 'series',
+			},
+			{
+				id: 'tr-casted-other',
+				name: 'DMM TR Library',
+				type: 'other',
+				extra: [{ name: 'skip' }],
+			},
+		],
+		behaviorHints: { adult: false, p2p: false },
+	});
+}

--- a/src/pages/api/stremio-tr/[userid]/meta/other/[id].ts
+++ b/src/pages/api/stremio-tr/[userid]/meta/other/[id].ts
@@ -24,16 +24,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		return;
 	}
 
-	const parts = idStr.split(':');
-	if (parts.length < 2) {
+	const torrentId = idStr.slice('dmm-tr:'.length);
+	if (!torrentId) {
 		res.status(400).json({
 			status: 'error',
 			errorMessage: 'Invalid id format. Expected dmm-tr:{torrentId}',
 		});
 		return;
 	}
-
-	const torrentId = parts[1];
 
 	const result = await getTorrinDMMTorrent(userid, torrentId);
 

--- a/src/pages/api/stremio-tr/[userid]/meta/other/[id].ts
+++ b/src/pages/api/stremio-tr/[userid]/meta/other/[id].ts
@@ -1,0 +1,45 @@
+import { getTorrinDMMTorrent } from '@/utils/torrinCastCatalogHelper';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { userid, id } = req.query;
+	if (typeof userid !== 'string' || typeof id !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" or "id" query parameter',
+		});
+		return;
+	}
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	const idStr = id.replace('.json', '');
+
+	if (!idStr.startsWith('dmm-tr:')) {
+		res.status(200).json({ meta: null });
+		return;
+	}
+
+	const parts = idStr.split(':');
+	if (parts.length < 2) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid id format. Expected dmm-tr:{torrentId}',
+		});
+		return;
+	}
+
+	const torrentId = parts[1];
+
+	const result = await getTorrinDMMTorrent(userid, torrentId);
+
+	if ('error' in result) {
+		return res.status(result.status).json({ error: result.error });
+	}
+
+	res.status(result.status).json(result.data);
+}

--- a/src/pages/api/stremio-tr/[userid]/no-catalog/manifest.json.ts
+++ b/src/pages/api/stremio-tr/[userid]/no-catalog/manifest.json.ts
@@ -1,0 +1,28 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	const host = req.headers.host || '';
+	const isDev = !host.includes('debridmediamanager.com');
+	const name = isDev ? '[LOCAL] DMM Cast for Torrin (No Library)' : 'DMM Cast for Torrin';
+
+	res.setHeader('access-control-allow-origin', '*');
+	res.status(200).json({
+		id: 'com.debridmediamanager.cast.torrin',
+		name,
+		description:
+			'Cast your preferred Debrid Media Manager streams to your Stremio device using Torrin; supports Anime, TV shows and Movies!',
+		logo: 'https://static.debridmediamanager.com/dmmcast.png',
+		background: 'https://static.debridmediamanager.com/background.png',
+		version: '0.0.1',
+		resources: [
+			{
+				name: 'stream',
+				types: ['movie', 'series'],
+				idPrefixes: ['tt'],
+			},
+		],
+		types: ['movie', 'series'],
+		catalogs: [],
+		behaviorHints: { adult: false, p2p: false },
+	});
+}

--- a/src/pages/api/stremio-tr/[userid]/play/[link].ts
+++ b/src/pages/api/stremio-tr/[userid]/play/[link].ts
@@ -1,0 +1,52 @@
+import { repository as db } from '@/services/repository';
+import { unrestrictTorrinLink } from '@/services/torrin';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+	res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+
+	const { userid, link } = req.query;
+	if (typeof userid !== 'string' || typeof link !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid" or "link" query parameter',
+		});
+		return;
+	}
+
+	let profile: { baseUrl: string; apiKey: string } | null = null;
+	try {
+		profile = await db.getTorrinCastProfile(userid);
+		if (!profile) {
+			throw new Error(`no profile found for user ${userid}`);
+		}
+	} catch (error) {
+		console.error(
+			'Failed to get Torrin profile:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: `Failed to get Torrin profile for user ${userid}` });
+		return;
+	}
+
+	try {
+		const restrictable = decodeURIComponent(link);
+		const unrestrict = await unrestrictTorrinLink(
+			profile.baseUrl,
+			profile.apiKey,
+			restrictable
+		);
+		if (!unrestrict || !unrestrict.download) {
+			res.status(500).json({ error: 'Failed to unrestrict link' });
+			return;
+		}
+		res.redirect(unrestrict.download);
+	} catch (error) {
+		console.error(
+			'Failed to play Torrin link:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: 'Failed to play link' });
+	}
+}

--- a/src/pages/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].ts
+++ b/src/pages/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].ts
@@ -70,6 +70,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 			db.getTorrinOtherStreams(
 				imdbidStr,
 				userid,
+				profile.baseUrl,
 				otherStreamsLimit,
 				maxSize > 0 ? maxSize : undefined
 			),

--- a/src/pages/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].ts
+++ b/src/pages/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].ts
@@ -1,0 +1,148 @@
+import { withRateLimit } from '@/services/rateLimit/withRateLimit';
+import { repository as db } from '@/services/repository';
+import {
+	extractStreamMetadata,
+	formatStremioStreamTitle,
+	generateStreamName,
+} from '@/utils/streamMetadata';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { userid, mediaType, imdbid } = req.query;
+
+	if (typeof userid !== 'string' || typeof imdbid !== 'string' || typeof mediaType !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid "userid", "imdbid" or "mediaType" query parameter',
+		});
+		return;
+	}
+
+	if (req.method === 'OPTIONS') {
+		return res.status(200).end();
+	}
+
+	let profile;
+	try {
+		profile = await db.getTorrinCastProfile(userid);
+		if (!profile) {
+			throw new Error(`no profile found for user ${userid}`);
+		}
+	} catch (error) {
+		console.error(
+			'Failed to get Torrin profile:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: `Failed to get Torrin profile for user ${userid}` });
+		return;
+	}
+
+	const imdbidStr = imdbid.replace(/\.json$/, '');
+	const typeSlug = mediaType === 'movie' ? 'movie' : 'show';
+	let externalUrl = `${process.env.DMM_ORIGIN}/${typeSlug}/${imdbidStr}`;
+	if (typeSlug === 'show') {
+		const [imdbid2, season] = imdbidStr.split(':');
+		externalUrl = `${process.env.DMM_ORIGIN}/${typeSlug}/${imdbid2}/${season}`;
+	}
+
+	const streams: any[] = [];
+
+	if (!profile.hideCastOption) {
+		streams.push({
+			name: 'DMM Cast TR✨',
+			title: 'Cast a file inside a torrent',
+			externalUrl,
+			behaviorHints: {
+				bingeGroup: `dmm-tr:${imdbidStr}:cast`,
+			},
+		});
+	}
+
+	try {
+		const maxSize = typeSlug === 'movie' ? profile.movieMaxSize : profile.episodeMaxSize;
+		const rawLimit = profile.otherStreamsLimit ?? 5;
+		const otherStreamsLimit = Math.max(0, Math.min(5, rawLimit));
+
+		const [userCastItems, otherItems] = await Promise.all([
+			db.getTorrinUserCastStreams(imdbidStr, userid, 5),
+			db.getTorrinOtherStreams(
+				imdbidStr,
+				userid,
+				otherStreamsLimit,
+				maxSize > 0 ? maxSize : undefined
+			),
+		]);
+
+		const allHashes = [
+			...userCastItems.map((item) => item.hash),
+			...otherItems.map((item) => item.hash),
+		];
+		const uniqueHashes = Array.from(new Set(allHashes));
+
+		const snapshots = await db.getSnapshotsByHashes(uniqueHashes);
+		const snapshotMap = new Map(snapshots.map((s) => [s.hash, s]));
+
+		for (const item of userCastItems) {
+			const snapshot = snapshotMap.get(item.hash);
+			const metadata = snapshot ? extractStreamMetadata(snapshot.payload) : null;
+			const title = formatStremioStreamTitle(
+				item.filename ?? 'Unknown Title',
+				item.size,
+				metadata,
+				true,
+				'TR'
+			);
+			const name = generateStreamName(item.size, metadata);
+			const playUrl = `${process.env.DMM_ORIGIN}/api/stremio-tr/${userid}/play/${encodeURIComponent(item.link)}`;
+
+			streams.push({
+				name,
+				title,
+				url: playUrl,
+				behaviorHints: {
+					bingeGroup: `dmm-tr:${imdbidStr}:yours`,
+				},
+			} as any);
+		}
+
+		for (let i = 0; i < otherItems.length; i++) {
+			const item = otherItems[i];
+			const snapshot = snapshotMap.get(item.hash);
+			const metadata = snapshot ? extractStreamMetadata(snapshot.payload) : null;
+			const title = formatStremioStreamTitle(
+				item.filename ?? 'Unknown Title',
+				item.size,
+				metadata,
+				false,
+				'TR'
+			);
+			const name = generateStreamName(item.size, metadata);
+			const playUrl = `${process.env.DMM_ORIGIN}/api/stremio-tr/${userid}/play/${encodeURIComponent(item.link)}`;
+
+			streams.push({
+				name,
+				title,
+				url: playUrl,
+				behaviorHints: {
+					bingeGroup: `dmm-tr:${imdbidStr}:other:${i + 1}`,
+				},
+			} as any);
+		}
+
+		res.status(200).json({
+			streams,
+			cacheMaxAge: 0,
+		});
+	} catch (error) {
+		console.error(
+			'Failed to get Torrin casted URLs:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		res.status(500).json({ error: 'Failed to get Torrin casted URLs' });
+		return;
+	}
+}
+
+export default withRateLimit(handler);

--- a/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
+++ b/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
@@ -39,10 +39,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 	try {
 		tInfo = await getTorrinTorrentInfo(baseUrl, apiKey, torrentId);
 	} catch (error) {
+		console.error(error);
 		res.status(502).json({
 			status: 'error',
 			errorMessage: 'Failed to fetch torrent info from Torrin',
-			details: error instanceof Error ? error.message : String(error),
 		});
 		return;
 	}
@@ -59,10 +59,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 	try {
 		userid = await generateTorrinUserId(baseUrl, apiKey);
 	} catch (error) {
+		console.error(error);
 		res.status(500).json({
 			status: 'error',
 			errorMessage: 'Failed to generate user ID from Torrin credentials.',
-			details: error instanceof Error ? error.message : String(error),
 		});
 		return;
 	}
@@ -71,10 +71,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 	try {
 		imdbid = (await db.getIMDBIdByHash(hash)) || '';
 	} catch (error) {
+		console.error(error);
 		res.status(500).json({
 			status: 'error',
 			errorMessage: 'Database error: Failed to retrieve IMDB ID from hash',
-			details: error instanceof Error ? error.message : String(error),
 		});
 		return;
 	}
@@ -91,10 +91,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			await db.saveIMDBIdMapping(tInfo.hash, userProvidedImdbId);
 			imdbid = userProvidedImdbId;
 		} catch (error) {
+			console.error(error);
 			res.status(500).json({
 				status: 'error',
 				errorMessage: 'Database error: Failed to save IMDB ID mapping',
-				details: error instanceof Error ? error.message : String(error),
 			});
 			return;
 		}
@@ -122,10 +122,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		try {
 			info = ptt.parse(selectedFile.path.split('/').pop() || '');
 		} catch (error) {
+			console.error(error);
 			res.status(500).json({
 				status: 'error',
 				errorMessage: `Failed to parse filename: ${selectedFile.path}`,
-				details: error instanceof Error ? error.message : String(error),
 			});
 			return;
 		}
@@ -138,13 +138,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 				tInfo.hash,
 				selectedFile.path,
 				tInfo.links[i],
-				Math.ceil(selectedFile.bytes / 1024 / 1024)
+				Math.ceil(selectedFile.bytes / 1024 / 1024),
+				baseUrl
 			);
 		} catch (error) {
+			console.error(error);
 			res.status(500).json({
 				status: 'error',
 				errorMessage: 'Database error: Failed to save cast information',
-				details: error instanceof Error ? error.message : String(error),
 			});
 			return;
 		}

--- a/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
+++ b/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
@@ -27,8 +27,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 	}
 
 	const [torrentId, hash] = torrentIdPlusHash.split(':');
+	if (!torrentId || !hash) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Invalid torrentIdPlusHash format. Expected "torrentId:hash"',
+		});
+		return;
+	}
 
-	const tInfo = await getTorrinTorrentInfo(baseUrl, apiKey, torrentId);
+	let tInfo;
+	try {
+		tInfo = await getTorrinTorrentInfo(baseUrl, apiKey, torrentId);
+	} catch (error) {
+		res.status(502).json({
+			status: 'error',
+			errorMessage: 'Failed to fetch torrent info from Torrin',
+			details: error instanceof Error ? error.message : String(error),
+		});
+		return;
+	}
 	const selectedFiles = tInfo.files.filter((f) => f.selected);
 	if (selectedFiles.length !== tInfo.links.length) {
 		res.status(400).json({

--- a/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
+++ b/src/pages/api/stremio-tr/cast/library/[torrentIdPlusHash].ts
@@ -1,0 +1,155 @@
+import { repository as db } from '@/services/repository';
+import { getTorrinTorrentInfo } from '@/services/torrin';
+import { getStremioDetailUrl } from '@/utils/stremioLinks';
+import { generateTorrinUserId } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+import ptt from 'parse-torrent-title';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { torrentIdPlusHash, baseUrl, apiKey, imdbId: userProvidedImdbId } = req.query;
+
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid Torrin baseUrl/apiKey',
+		});
+		return;
+	}
+
+	if (!torrentIdPlusHash || typeof torrentIdPlusHash !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid torrentid',
+		});
+		return;
+	}
+
+	const [torrentId, hash] = torrentIdPlusHash.split(':');
+
+	const tInfo = await getTorrinTorrentInfo(baseUrl, apiKey, torrentId);
+	const selectedFiles = tInfo.files.filter((f) => f.selected);
+	if (selectedFiles.length !== tInfo.links.length) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Cannot determine file link',
+		});
+		return;
+	}
+
+	let userid: string;
+	try {
+		userid = await generateTorrinUserId(baseUrl, apiKey);
+	} catch (error) {
+		res.status(500).json({
+			status: 'error',
+			errorMessage: 'Failed to generate user ID from Torrin credentials.',
+			details: error instanceof Error ? error.message : String(error),
+		});
+		return;
+	}
+
+	let imdbid = '';
+	try {
+		imdbid = (await db.getIMDBIdByHash(hash)) || '';
+	} catch (error) {
+		res.status(500).json({
+			status: 'error',
+			errorMessage: 'Database error: Failed to retrieve IMDB ID from hash',
+			details: error instanceof Error ? error.message : String(error),
+		});
+		return;
+	}
+
+	if (!imdbid && userProvidedImdbId && typeof userProvidedImdbId === 'string') {
+		if (!/^tt\d{7,}$/.test(userProvidedImdbId)) {
+			res.status(400).json({
+				status: 'error',
+				errorMessage: 'Invalid IMDB ID format. Expected format: tt1234567',
+			});
+			return;
+		}
+		try {
+			await db.saveIMDBIdMapping(tInfo.hash, userProvidedImdbId);
+			imdbid = userProvidedImdbId;
+		} catch (error) {
+			res.status(500).json({
+				status: 'error',
+				errorMessage: 'Database error: Failed to save IMDB ID mapping',
+				details: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+	}
+
+	if (!imdbid) {
+		res.status(200).json({
+			status: 'need_imdb_id',
+			torrentInfo: {
+				title: tInfo.filename || tInfo.original_filename,
+				filename: tInfo.original_filename || tInfo.filename,
+				hash: tInfo.hash,
+				files: selectedFiles.map((f) => ({
+					path: f.path,
+					bytes: f.bytes,
+				})),
+			},
+		});
+		return;
+	}
+
+	for (let i = 0; i < selectedFiles.length; i++) {
+		const selectedFile = selectedFiles[i];
+		let info;
+		try {
+			info = ptt.parse(selectedFile.path.split('/').pop() || '');
+		} catch (error) {
+			res.status(500).json({
+				status: 'error',
+				errorMessage: `Failed to parse filename: ${selectedFile.path}`,
+				details: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+
+		try {
+			const stremioKey = `${imdbid}${info.season && info.episode ? `:${info.season}:${info.episode}` : ''}`;
+			await db.saveTorrinCast(
+				stremioKey,
+				userid,
+				tInfo.hash,
+				selectedFile.path,
+				tInfo.links[i],
+				Math.ceil(selectedFile.bytes / 1024 / 1024)
+			);
+		} catch (error) {
+			res.status(500).json({
+				status: 'error',
+				errorMessage: 'Database error: Failed to save cast information',
+				details: error instanceof Error ? error.message : String(error),
+			});
+			return;
+		}
+	}
+
+	const firstFileInfo = ptt.parse(selectedFiles[0].path.split('/').pop() || '');
+	const season = firstFileInfo.season ? String(firstFileInfo.season) : '';
+	const episode = firstFileInfo.episode ? String(firstFileInfo.episode) : '';
+
+	let redirectUrl = getStremioDetailUrl(imdbid);
+	let mediaType = 'movie';
+	if (season && episode) {
+		redirectUrl = getStremioDetailUrl(imdbid, { season, episode });
+		mediaType = 'series';
+	}
+
+	res.status(200).json({
+		status: 'success',
+		redirectUrl,
+		imdbId: imdbid,
+		mediaType,
+		season: season || undefined,
+		episode: episode || undefined,
+	});
+}

--- a/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
@@ -1,0 +1,59 @@
+import { repository as db } from '@/services/repository';
+import { getBiggestFileTorrinStreamUrl } from '@/utils/getTorrinStreamUrl';
+import { generateTorrinUserId } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { imdbid, hash, baseUrl, apiKey } = req.query;
+
+	if (
+		!apiKey ||
+		typeof apiKey !== 'string' ||
+		!baseUrl ||
+		typeof baseUrl !== 'string' ||
+		!hash ||
+		typeof hash !== 'string' ||
+		typeof imdbid !== 'string'
+	) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl", "apiKey", "hash" or "imdbid" parameter',
+		});
+		return;
+	}
+
+	try {
+		const [streamUrl, trLink, fileSize] = await getBiggestFileTorrinStreamUrl(
+			baseUrl,
+			apiKey,
+			hash
+		);
+
+		if (streamUrl) {
+			const userid = await generateTorrinUserId(baseUrl, apiKey);
+			await db.saveTorrinCast(imdbid, userid, hash, streamUrl, trLink, fileSize);
+
+			const filename = streamUrl.split('/').pop() ?? '???';
+			res.status(200).json({
+				status: 'success',
+				message: 'You can now stream the movie in Stremio',
+				filename,
+			});
+			return;
+		}
+
+		res.status(500).json({
+			status: 'error',
+			errorMessage: 'Failed to get a streamable file',
+		});
+	} catch (e) {
+		console.error(e);
+		const message = e instanceof Error ? e.message : String(e);
+		res.status(500).json({
+			status: 'error',
+			errorMessage: message,
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
 		if (streamUrl) {
 			const userid = await generateTorrinUserId(baseUrl, apiKey);
-			await db.saveTorrinCast(imdbid, userid, hash, streamUrl, trLink, fileSize);
+			await db.saveTorrinCast(imdbid, userid, hash, streamUrl, trLink, fileSize, baseUrl);
 
 			const filename = streamUrl.split('/').pop() ?? '???';
 			res.status(200).json({
@@ -51,10 +51,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		return;
 	} catch (e) {
 		console.error(e);
-		const message = e instanceof Error ? e.message : String(e);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: message,
+			errorMessage: 'Failed to cast the movie',
 		});
 	}
 }

--- a/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/movie/[imdbid].ts
@@ -48,6 +48,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 			status: 'error',
 			errorMessage: 'Failed to get a streamable file',
 		});
+		return;
 	} catch (e) {
 		console.error(e);
 		const message = e instanceof Error ? e.message : String(e);

--- a/src/pages/api/stremio-tr/cast/saveProfile.ts
+++ b/src/pages/api/stremio-tr/cast/saveProfile.ts
@@ -73,7 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		console.error('Error saving Torrin cast profile:', error);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+			errorMessage: 'Failed to save cast profile',
 		});
 	}
 }

--- a/src/pages/api/stremio-tr/cast/saveProfile.ts
+++ b/src/pages/api/stremio-tr/cast/saveProfile.ts
@@ -1,0 +1,75 @@
+import { repository as db } from '@/services/repository';
+import { generateTorrinUserId, validateTorrinApiKey } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method !== 'POST') {
+		res.setHeader('Allow', ['POST']);
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+		return;
+	}
+
+	const { baseUrl, apiKey, movieMaxSize, episodeMaxSize, otherStreamsLimit, hideCastOption } =
+		req.body;
+
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl"/"apiKey" in request body',
+		});
+		return;
+	}
+
+	if (otherStreamsLimit !== undefined) {
+		const limit = Number(otherStreamsLimit);
+		if (!Number.isInteger(limit) || limit < 0 || limit > 5) {
+			res.status(400).json({
+				status: 'error',
+				errorMessage: 'otherStreamsLimit must be an integer between 0 and 5',
+			});
+			return;
+		}
+	}
+
+	try {
+		const validation = await validateTorrinApiKey(baseUrl, apiKey);
+		if (!validation.valid) {
+			res.status(401).json({
+				status: 'error',
+				errorMessage: 'Invalid Torrin credentials',
+			});
+			return;
+		}
+
+		const userId = await generateTorrinUserId(baseUrl, apiKey);
+
+		const profile = await db.saveTorrinCastProfile(
+			userId,
+			baseUrl,
+			apiKey,
+			typeof movieMaxSize === 'number' ? movieMaxSize : undefined,
+			typeof episodeMaxSize === 'number' ? episodeMaxSize : undefined,
+			typeof otherStreamsLimit === 'number' ? otherStreamsLimit : undefined,
+			hideCastOption !== undefined ? Boolean(hideCastOption) : undefined
+		);
+
+		res.status(200).json({
+			status: 'success',
+			profile: {
+				userId: profile.userId,
+				movieMaxSize: profile.movieMaxSize,
+				episodeMaxSize: profile.episodeMaxSize,
+				otherStreamsLimit: profile.otherStreamsLimit,
+				hideCastOption: profile.hideCastOption,
+			},
+		});
+	} catch (error) {
+		console.error('Error saving Torrin cast profile:', error);
+		res.status(500).json({
+			status: 'error',
+			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/cast/saveProfile.ts
+++ b/src/pages/api/stremio-tr/cast/saveProfile.ts
@@ -23,8 +23,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 	}
 
 	if (otherStreamsLimit !== undefined) {
-		const limit = Number(otherStreamsLimit);
-		if (!Number.isInteger(limit) || limit < 0 || limit > 5) {
+		if (
+			typeof otherStreamsLimit !== 'number' ||
+			!Number.isInteger(otherStreamsLimit) ||
+			otherStreamsLimit < 0 ||
+			otherStreamsLimit > 5
+		) {
 			res.status(400).json({
 				status: 'error',
 				errorMessage: 'otherStreamsLimit must be an integer between 0 and 5',

--- a/src/pages/api/stremio-tr/cast/series/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/series/[imdbid].ts
@@ -50,7 +50,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 						? `:${seasonNumber}:${episodeNumber}`
 						: ''
 				}`;
-				await db.saveTorrinCast(castKey, userid, hash, streamUrl, trLink, fileSize);
+				await db.saveTorrinCast(
+					castKey,
+					userid,
+					hash,
+					streamUrl,
+					trLink,
+					fileSize,
+					baseUrl
+				);
 			} else if (seasonNumber >= 0 && episodeNumber >= 0) {
 				errorEpisodes.push(`S${seasonNumber}E${episodeNumber}`);
 			} else {

--- a/src/pages/api/stremio-tr/cast/series/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/series/[imdbid].ts
@@ -1,0 +1,59 @@
+import { repository as db } from '@/services/repository';
+import { getTorrinStreamUrl } from '@/utils/getTorrinStreamUrl';
+import { generateTorrinUserId } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	const { imdbid, hash, fileIds, baseUrl, apiKey } = req.query;
+
+	if (
+		!apiKey ||
+		typeof apiKey !== 'string' ||
+		!baseUrl ||
+		typeof baseUrl !== 'string' ||
+		!hash ||
+		typeof hash !== 'string' ||
+		typeof imdbid !== 'string' ||
+		!fileIds ||
+		(!Array.isArray(fileIds) && typeof fileIds !== 'string')
+	) {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl", "apiKey", "hash", "imdbid" or "fileIds"',
+		});
+		return;
+	}
+
+	const errorEpisodes: string[] = [];
+	const fileIdsArr = Array.isArray(fileIds) ? fileIds : [fileIds];
+	const userid = await generateTorrinUserId(baseUrl, apiKey);
+
+	for (const fileId of fileIdsArr) {
+		try {
+			const [streamUrl, trLink, seasonNumber, episodeNumber, fileSize] =
+				await getTorrinStreamUrl(baseUrl, apiKey, hash, parseInt(fileId, 10), 'tv');
+
+			if (streamUrl) {
+				const castKey = `${imdbid}${
+					seasonNumber >= 0 && episodeNumber >= 0
+						? `:${seasonNumber}:${episodeNumber}`
+						: ''
+				}`;
+				await db.saveTorrinCast(castKey, userid, hash, streamUrl, trLink, fileSize);
+			} else if (seasonNumber >= 0 && episodeNumber >= 0) {
+				errorEpisodes.push(`S${seasonNumber}E${episodeNumber}`);
+			} else {
+				errorEpisodes.push(`fileId:${fileId}`);
+			}
+		} catch (e) {
+			console.error(e);
+			errorEpisodes.push(`fileId:${fileId}`);
+		}
+	}
+
+	res.status(200).json({
+		errorEpisodes,
+	});
+}

--- a/src/pages/api/stremio-tr/cast/series/[imdbid].ts
+++ b/src/pages/api/stremio-tr/cast/series/[imdbid].ts
@@ -1,6 +1,6 @@
 import { repository as db } from '@/services/repository';
 import { getTorrinStreamUrl } from '@/utils/getTorrinStreamUrl';
-import { generateTorrinUserId } from '@/utils/torrinCastApiHelpers';
+import { generateTorrinUserId, validateTorrinApiKey } from '@/utils/torrinCastApiHelpers';
 import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -22,6 +22,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		res.status(400).json({
 			status: 'error',
 			errorMessage: 'Missing or invalid "baseUrl", "apiKey", "hash", "imdbid" or "fileIds"',
+		});
+		return;
+	}
+
+	const validation = await validateTorrinApiKey(baseUrl, apiKey);
+	if (!validation.valid) {
+		res.status(401).json({
+			status: 'error',
+			errorMessage: 'Invalid Torrin credentials',
 		});
 		return;
 	}

--- a/src/pages/api/stremio-tr/cast/updateSizeLimits.ts
+++ b/src/pages/api/stremio-tr/cast/updateSizeLimits.ts
@@ -1,0 +1,75 @@
+import { repository as db } from '@/services/repository';
+import { generateTorrinUserId, validateTorrinApiKey } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method !== 'POST') {
+		res.setHeader('Allow', ['POST']);
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+		return;
+	}
+
+	const { baseUrl, apiKey, movieMaxSize, episodeMaxSize, otherStreamsLimit, hideCastOption } =
+		req.body;
+
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl"/"apiKey" in request body',
+		});
+		return;
+	}
+
+	if (otherStreamsLimit !== undefined) {
+		const limit = Number(otherStreamsLimit);
+		if (!Number.isInteger(limit) || limit < 0 || limit > 5) {
+			res.status(400).json({
+				status: 'error',
+				errorMessage: 'otherStreamsLimit must be an integer between 0 and 5',
+			});
+			return;
+		}
+	}
+
+	try {
+		const validation = await validateTorrinApiKey(baseUrl, apiKey);
+		if (!validation.valid) {
+			res.status(401).json({
+				status: 'error',
+				errorMessage: 'Invalid Torrin credentials',
+			});
+			return;
+		}
+
+		const userId = await generateTorrinUserId(baseUrl, apiKey);
+
+		const profile = await db.saveTorrinCastProfile(
+			userId,
+			baseUrl,
+			apiKey,
+			typeof movieMaxSize === 'number' ? movieMaxSize : undefined,
+			typeof episodeMaxSize === 'number' ? episodeMaxSize : undefined,
+			typeof otherStreamsLimit === 'number' ? otherStreamsLimit : undefined,
+			hideCastOption !== undefined ? Boolean(hideCastOption) : undefined
+		);
+
+		res.status(200).json({
+			status: 'success',
+			profile: {
+				userId: profile.userId,
+				movieMaxSize: profile.movieMaxSize,
+				episodeMaxSize: profile.episodeMaxSize,
+				otherStreamsLimit: profile.otherStreamsLimit,
+				hideCastOption: profile.hideCastOption,
+			},
+		});
+	} catch (error) {
+		console.error('Error updating Torrin cast size limits:', error);
+		res.status(500).json({
+			status: 'error',
+			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/cast/updateSizeLimits.ts
+++ b/src/pages/api/stremio-tr/cast/updateSizeLimits.ts
@@ -69,7 +69,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		console.error('Error updating Torrin cast size limits:', error);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+			errorMessage: 'Failed to update size limits',
 		});
 	}
 }

--- a/src/pages/api/stremio-tr/deletelink.ts
+++ b/src/pages/api/stremio-tr/deletelink.ts
@@ -50,7 +50,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		console.error('Error deleting Torrin casted link:', error);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+			errorMessage: 'Failed to delete link',
 		});
 	}
 }

--- a/src/pages/api/stremio-tr/deletelink.ts
+++ b/src/pages/api/stremio-tr/deletelink.ts
@@ -1,0 +1,56 @@
+import { repository as db } from '@/services/repository';
+import { generateTorrinUserId, validateTorrinApiKey } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method !== 'DELETE') {
+		res.setHeader('Allow', ['DELETE']);
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+		return;
+	}
+
+	const { apiKey, baseUrl, imdbId, hash } = req.body;
+
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl"/"apiKey" in request body',
+		});
+		return;
+	}
+
+	if (!imdbId || typeof imdbId !== 'string' || !hash || typeof hash !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "imdbId" or "hash" in request body',
+		});
+		return;
+	}
+
+	try {
+		const validation = await validateTorrinApiKey(baseUrl, apiKey);
+		if (!validation.valid) {
+			res.status(401).json({
+				status: 'error',
+				errorMessage: 'Invalid Torrin credentials',
+			});
+			return;
+		}
+
+		const userId = await generateTorrinUserId(baseUrl, apiKey);
+		await db.deleteTorrinCastedLink(imdbId, userId, hash);
+
+		res.status(200).json({
+			status: 'success',
+			message: 'Link deleted successfully',
+		});
+	} catch (error) {
+		console.error('Error deleting Torrin casted link:', error);
+		res.status(500).json({
+			status: 'error',
+			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/id.ts
+++ b/src/pages/api/stremio-tr/id.ts
@@ -17,9 +17,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		const id = await generateTorrinUserId(creds.baseUrl, creds.apiKey);
 		res.status(200).json({ id });
 	} catch (error) {
+		console.error(error);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+			errorMessage: 'Failed to generate user ID',
 		});
 	}
 }

--- a/src/pages/api/stremio-tr/id.ts
+++ b/src/pages/api/stremio-tr/id.ts
@@ -1,0 +1,25 @@
+import {
+	generateTorrinUserId,
+	validateMethod,
+	validateTorrinCreds,
+} from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (!validateMethod(req, res, ['GET'])) return;
+
+	const creds = validateTorrinCreds(req, res);
+	if (!creds) return;
+
+	try {
+		const id = await generateTorrinUserId(creds.baseUrl, creds.apiKey);
+		res.status(200).json({ id });
+	} catch (error) {
+		res.status(500).json({
+			status: 'error',
+			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/links.ts
+++ b/src/pages/api/stremio-tr/links.ts
@@ -1,0 +1,48 @@
+import { repository as db } from '@/services/repository';
+import { generateTorrinUserId, validateTorrinApiKey } from '@/utils/torrinCastApiHelpers';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+	res.setHeader('access-control-allow-origin', '*');
+
+	if (req.method !== 'GET') {
+		res.setHeader('Allow', ['GET']);
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+		return;
+	}
+
+	const { apiKey, baseUrl } = req.query;
+
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(400).json({
+			status: 'error',
+			errorMessage: 'Missing or invalid "baseUrl"/"apiKey" query parameters',
+		});
+		return;
+	}
+
+	try {
+		const validation = await validateTorrinApiKey(baseUrl, apiKey);
+		if (!validation.valid) {
+			res.status(401).json({
+				status: 'error',
+				errorMessage: 'Invalid Torrin credentials',
+			});
+			return;
+		}
+
+		const userId = await generateTorrinUserId(baseUrl, apiKey);
+		const links = await db.fetchAllTorrinCastedLinks(userId);
+
+		res.status(200).json({
+			status: 'success',
+			links,
+		});
+	} catch (error) {
+		console.error('Error fetching Torrin casted links:', error);
+		res.status(500).json({
+			status: 'error',
+			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+		});
+	}
+}

--- a/src/pages/api/stremio-tr/links.ts
+++ b/src/pages/api/stremio-tr/links.ts
@@ -42,7 +42,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		console.error('Error fetching Torrin casted links:', error);
 		res.status(500).json({
 			status: 'error',
-			errorMessage: error instanceof Error ? error.message : 'Unknown error',
+			errorMessage: 'Failed to fetch casted links',
 		});
 	}
 }

--- a/src/pages/api/stremio/[userid]/meta/other/[id].ts
+++ b/src/pages/api/stremio/[userid]/meta/other/[id].ts
@@ -51,8 +51,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 		// Clean up the ID - remove prefix and .json suffix
 		const cleanId = id.replaceAll(/\.json$/g, '');
 
-		// Skip if this is an AllDebrid or TorBox ID - let those addons handle it
-		if (cleanId.startsWith('dmm-ad:') || cleanId.startsWith('dmm-tb:')) {
+		// Skip if this is an AllDebrid, TorBox, or Torrin ID - let those addons handle it
+		if (
+			cleanId.startsWith('dmm-ad:') ||
+			cleanId.startsWith('dmm-tb:') ||
+			cleanId.startsWith('dmm-tr:')
+		) {
 			console.log('[meta/other/id] Skipping non-RD ID:', cleanId);
 			res.status(200).json({ meta: null });
 			return;

--- a/src/pages/hashlist.tsx
+++ b/src/pages/hashlist.tsx
@@ -732,7 +732,8 @@ function HashlistPage() {
 	async function addTr(hash: string) {
 		try {
 			const instantResp = await torrinInstantCheck(torrinBaseUrl!, torrinApiKey!, [hash]);
-			if (!instantResp?.[hash] && !instantResp?.[hash.toLowerCase()]) {
+			const entry = instantResp?.[hash.toLowerCase()] as any;
+			if (!(entry?.rd?.length > 0)) {
 				toast.error('Torrent not instant in Torrin; skipped.', genericToastOptions);
 				return;
 			}

--- a/src/pages/hashlist.tsx
+++ b/src/pages/hashlist.tsx
@@ -1,5 +1,10 @@
 import { useLibraryCache } from '@/contexts/LibraryCacheContext';
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { adInstantCheck, getMagnetStatus, uploadMagnet } from '@/services/allDebrid';
 import { EnrichedHashlistTorrent, Hashlist, HashlistTorrent } from '@/services/mediasearch';
 import {
@@ -8,6 +13,12 @@ import {
 	getTorrentList,
 	TorBoxRateLimitError,
 } from '@/services/torbox';
+import {
+	addTorrinMagnet,
+	getTorrinTorrentInfo,
+	selectTorrinFiles,
+	torrinInstantCheck,
+} from '@/services/torrin';
 import { TorBoxTorrentInfo } from '@/services/types';
 import UserTorrentDB from '@/torrent/db';
 import { handleAddAsMagnetInRd } from '@/utils/addMagnet';
@@ -16,16 +27,19 @@ import {
 	handleDeleteAdTorrent,
 	handleDeleteRdTorrent,
 	handleDeleteTbTorrent,
+	handleDeleteTrTorrent,
 } from '@/utils/deleteTorrent';
 import {
 	convertToAllDebridUserTorrent,
 	convertToTbUserTorrent,
+	convertToTorrinUserTorrent,
 	convertToUserTorrent,
 } from '@/utils/fetchTorrents';
 import {
 	checkDatabaseAvailabilityAd2,
 	checkDatabaseAvailabilityRd2,
 	checkDatabaseAvailabilityTb2,
+	checkDatabaseAvailabilityTr2,
 	wrapLoading,
 } from '@/utils/instantChecks';
 import { getMediaId } from '@/utils/mediaId';
@@ -74,6 +88,7 @@ function HashlistPage() {
 	const [rdKey] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
 	const { addTorrent: addToCache, removeTorrent: removeFromCache } = useLibraryCache();
 
 	const [currentPage, setCurrentPage] = useState(1);
@@ -166,7 +181,7 @@ function HashlistPage() {
 		if (userTorrentsList.length !== 0) return;
 		initialize();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [rdKey, adKey, tbKey]);
+	}, [rdKey, adKey, tbKey, torrinBaseUrl, torrinApiKey]);
 
 	async function decodeJsonStringFromUrl(): Promise<string> {
 		const hash = window.location.hash;
@@ -240,6 +255,16 @@ function HashlistPage() {
 				wrapLoading(
 					'TB',
 					checkDatabaseAvailabilityTb2(tbKey, hashArr, setUserTorrentsList)
+				);
+			if (torrinBaseUrl && torrinApiKey)
+				wrapLoading(
+					'TR',
+					checkDatabaseAvailabilityTr2(
+						torrinBaseUrl,
+						torrinApiKey,
+						hashArr,
+						setUserTorrentsList
+					)
 				);
 		} catch (error) {
 			console.error('Error fetching user torrents list:', error);
@@ -323,8 +348,10 @@ function HashlistPage() {
 		tmpList = tmpList.filter((t, i, self) => self.findIndex((s) => s.hash === t.hash) === i);
 
 		// Filter for instantly available torrents if enabled and keys are present
-		if (showOnlyAvailable && (rdKey || adKey || tbKey)) {
-			tmpList = tmpList.filter((t) => t.rdAvailable || t.adAvailable || t.tbAvailable);
+		if (showOnlyAvailable && (rdKey || adKey || tbKey || (torrinBaseUrl && torrinApiKey))) {
+			tmpList = tmpList.filter(
+				(t) => t.rdAvailable || t.adAvailable || t.tbAvailable || t.torrinAvailable
+			);
 		}
 
 		if (Object.keys(router.query).length === 0) {
@@ -702,6 +729,51 @@ function HashlistPage() {
 		}
 	}
 
+	async function addTr(hash: string) {
+		try {
+			const instantResp = await torrinInstantCheck(torrinBaseUrl!, torrinApiKey!, [hash]);
+			if (!instantResp?.[hash] && !instantResp?.[hash.toLowerCase()]) {
+				toast.error('Torrent not instant in Torrin; skipped.', genericToastOptions);
+				return;
+			}
+
+			const id = await addTorrinMagnet(torrinBaseUrl!, torrinApiKey!, hash);
+			await selectTorrinFiles(torrinBaseUrl!, torrinApiKey!, id, 'all');
+			const info = await getTorrinTorrentInfo(torrinBaseUrl!, torrinApiKey!, id);
+			const userTorrent = convertToTorrinUserTorrent({
+				id: info.id,
+				filename: info.filename,
+				bytes: info.bytes,
+				status: info.status,
+				added: info.added,
+				links: info.links,
+				hash: info.hash,
+			} as any);
+			await torrentDB.addAll([userTorrent]);
+			addToCache(userTorrent);
+			await fetchHashAndProgress(hash);
+			toast.success('Torrent added to Torrin.', genericToastOptions);
+		} catch (error) {
+			console.error('Error adding magnet to Torrin:', error);
+			toast.error('Failed to add hash to Torrin.', genericToastOptions);
+		}
+	}
+
+	async function deleteTr(hash: string) {
+		const torrents = await torrentDB.getAllByHash(hash);
+		for (const t of torrents) {
+			if (!t.id.startsWith('tr:')) continue;
+			await handleDeleteTrTorrent(torrinBaseUrl!, torrinApiKey!, t.id);
+			await torrentDB.deleteByHash('tr', hash);
+			removeFromCache(t.id);
+			setHashAndProgress((prev) => {
+				const newHashAndProgress = { ...prev };
+				delete newHashAndProgress[`tr:${hash}`];
+				return newHashAndProgress;
+			});
+		}
+	}
+
 	const handlePrevPage = useCallback(() => {
 		setCurrentPage((prev) => prev - 1);
 	}, []);
@@ -835,7 +907,7 @@ function HashlistPage() {
 				>
 					{tvCount} TV Shows
 				</Link>
-				{mounted && (rdKey || adKey || tbKey) && (
+				{mounted && (rdKey || adKey || tbKey || (torrinBaseUrl && torrinApiKey)) && (
 					<button
 						className={`mb-2 mr-2 rounded border-2 ${
 							showOnlyAvailable
@@ -913,7 +985,7 @@ function HashlistPage() {
 					</>
 				)}
 
-				{mounted && (rdKey || adKey || tbKey) && (
+				{mounted && (rdKey || adKey || tbKey || (torrinBaseUrl && torrinApiKey)) && (
 					<span className="text-s mr-2 bg-green-100 px-2.5 py-1 text-green-800">
 						<strong>{userTorrentsList.length - filteredList.length}</strong> hidden
 					</span>
@@ -1109,6 +1181,45 @@ function HashlistPage() {
 												>
 													<Download className="mr-1 inline h-3 w-3" />
 													TB
+												</button>
+											)}
+
+										{mounted &&
+											torrinBaseUrl &&
+											torrinApiKey &&
+											isDownloading('tr', t.hash) && (
+												<button
+													className="ml-2 rounded border-2 border-red-500 bg-red-900/30 px-2 py-1 text-red-100 transition-colors hover:bg-red-800/50"
+													onClick={() => deleteTr(t.hash)}
+												>
+													<X className="mr-1 inline h-3 w-3" />
+													TR ({hashAndProgress[`tr:${t.hash}`] || 0}%)
+												</button>
+											)}
+										{mounted &&
+											torrinBaseUrl &&
+											torrinApiKey &&
+											!t.torrinAvailable &&
+											notInLibrary('tr', t.hash) && (
+												<button
+													className="ml-2 rounded border-2 border-sky-500 bg-sky-900/30 px-2 py-1 text-sky-100 transition-colors hover:bg-sky-800/50"
+													onClick={() => addTr(t.hash)}
+												>
+													<Download className="mr-1 inline h-3 w-3" />
+													TR
+												</button>
+											)}
+										{mounted &&
+											torrinBaseUrl &&
+											torrinApiKey &&
+											t.torrinAvailable &&
+											notInLibrary('tr', t.hash) && (
+												<button
+													className="ml-2 rounded border-2 border-green-500 bg-green-900/30 px-2 py-1 text-green-100 transition-colors hover:bg-green-800/50"
+													onClick={() => addTr(t.hash)}
+												>
+													<Download className="mr-1 inline h-3 w-3" />
+													TR
 												</button>
 											)}
 									</td>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,6 +25,7 @@ function IndexPage() {
 		rdUser,
 		adUser,
 		tbUser,
+		torrinUser,
 		rdError,
 		adError,
 		tbError,
@@ -36,7 +37,8 @@ function IndexPage() {
 		hasTraktAuth,
 		isLoading,
 	} = useCurrentUser();
-	const { loginWithRealDebrid, loginWithAllDebrid, loginWithTorbox } = useDebridLogin();
+	const { loginWithRealDebrid, loginWithAllDebrid, loginWithTorbox, loginWithTorrin } =
+		useDebridLogin();
 	const [browseTerms] = useState(getTerms(2));
 	const [showElfHostedBanner, setShowElfHostedBanner] = useState(true);
 
@@ -204,6 +206,7 @@ function IndexPage() {
 							rdUser={rdUser}
 							tbUser={tbUser}
 							adUser={!!adUser}
+							torrinConnected={!!torrinUser}
 							isLoading={isLoading}
 						/>
 						<Link
@@ -235,6 +238,12 @@ function IndexPage() {
 								service="tb"
 								user={tbUser}
 								onTraktLogin={loginWithTorbox}
+								onLogout={async (prefix) => await handleLogout(prefix, router)}
+							/>
+							<ServiceCard
+								service="tr"
+								user={torrinUser}
+								onTraktLogin={loginWithTorrin}
 								onLogout={async (prefix) => await handleLogout(prefix, router)}
 							/>
 							<ServiceCard

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -1733,16 +1733,18 @@ function TorrentsPage() {
 				}
 			}
 			if (allHashes.length > 0) {
-				try {
-					for (const h of allHashes) {
-						const id = await addTorrinMagnet(torrinBaseUrl, torrinApiKey, h);
-						await selectTorrinFiles(torrinBaseUrl, torrinApiKey, id, 'all');
-					}
-					toast.success(`Added ${allHashes.length} to Torrin.`);
-					await refreshLibrary();
-				} catch (error) {
-					toast.error(`Torrin add failed: ${error}`);
+				const toAdd: AsyncFunction<unknown>[] = allHashes.map((h) => async () => {
+					const id = await addTorrinMagnet(torrinBaseUrl, torrinApiKey, h);
+					await selectTorrinFiles(torrinBaseUrl, torrinApiKey, id, 'all');
+				});
+				const [results, errors] = await runConcurrentFunctions(toAdd, 4, 0);
+				if (results.length > 0) {
+					toast.success(`Added ${results.length} to Torrin.`);
 				}
+				if (errors.length > 0) {
+					toast.error(`Torrin add failed for ${errors.length} of ${allHashes.length}.`);
+				}
+				await refreshLibrary();
 			}
 		}
 	}

--- a/src/pages/library.tsx
+++ b/src/pages/library.tsx
@@ -4,9 +4,15 @@ import LibrarySize from '@/components/LibrarySize';
 import LibraryTableHeader from '@/components/LibraryTableHeader';
 import LibraryTorrentRow from '@/components/LibraryTorrentRow';
 import { useLibraryCache } from '@/contexts/LibraryCacheContext';
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { useRelativeTimeLabel } from '@/hooks/useRelativeTimeLabel';
 import { getTorrentInfo, proxyUnrestrictLink } from '@/services/realDebrid';
+import { addTorrinMagnet, selectTorrinFiles } from '@/services/torrin';
 import UserTorrentDB from '@/torrent/db';
 import { UserTorrent, UserTorrentStatus } from '@/torrent/userTorrent';
 import {
@@ -27,6 +33,7 @@ import {
 	handleDeleteAdTorrent,
 	handleDeleteRdTorrent,
 	handleDeleteTbTorrent,
+	handleDeleteTrTorrent,
 } from '@/utils/deleteTorrent';
 import { extractHashes } from '@/utils/extractHashes';
 import { getRdStatus } from '@/utils/fetchTorrents';
@@ -40,6 +47,7 @@ import { isFailed, isInProgress, isSlowOrNoLinks } from '@/utils/slow';
 import { libraryToastOptions, magnetToastOptions, searchToastOptions } from '@/utils/toastOptions';
 import { getHashOfTorrent } from '@/utils/torrentFile';
 import { handleShowInfoForAD, handleShowInfoForRD, handleShowInfoForTB } from '@/utils/torrentInfo';
+import { handleShowInfoForTorrin } from '@/utils/torrinInfo';
 import { withAuth } from '@/utils/withAuth';
 import { saveAs } from 'file-saver';
 import { BookOpen } from 'lucide-react';
@@ -120,6 +128,7 @@ function TorrentsPage() {
 	const [rdKey] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
 
 	const [defaultTitleGrouping] = useState<Record<string, number>>(() => ({}));
 	const [movieTitleGrouping] = useState<Record<string, number>>(() => ({}));
@@ -274,9 +283,8 @@ function TorrentsPage() {
 						const magnetUri = hash.startsWith('magnet:?')
 							? hash
 							: `magnet:?xt=urn:btih:${hash}`;
-						const { uploadMagnet, getMagnetStatus } = await import(
-							'@/services/allDebrid'
-						);
+						const { uploadMagnet, getMagnetStatus } =
+							await import('@/services/allDebrid');
 						const resp = await uploadMagnet(adKey, [magnetUri]);
 						if (
 							resp.magnets.length > 0 &&
@@ -762,11 +770,14 @@ function TorrentsPage() {
 				if (tbKey && t.id.startsWith('tb:')) {
 					success = await handleDeleteTbTorrent(tbKey, t.id);
 				}
+				if (torrinBaseUrl && torrinApiKey && t.id.startsWith('tr:')) {
+					success = await handleDeleteTrTorrent(torrinBaseUrl, torrinApiKey, t.id);
+				}
 				if (!success) throw new Error(`Failed to delete ${t.id}`);
 				return t.id;
 			};
 		},
-		[rdKey, adKey, tbKey]
+		[rdKey, adKey, tbKey, torrinBaseUrl, torrinApiKey]
 	);
 
 	const wrapReinsertFn = useCallback(
@@ -1320,9 +1331,8 @@ function TorrentsPage() {
 								try {
 									let cachedCount = 0;
 									if (debridService === 'rd' && rdKey) {
-										const { checkAvailabilityByHashes } = await import(
-											'@/utils/availability'
-										);
+										const { checkAvailabilityByHashes } =
+											await import('@/utils/availability');
 										const availableSet = new Set<string>();
 										for (let i = 0; i < newHashes.length; i += 100) {
 											const batch = newHashes.slice(i, i + 100);
@@ -1339,9 +1349,8 @@ function TorrentsPage() {
 										}
 										cachedCount = availableSet.size;
 									} else if (debridService === 'tb' && tbKey) {
-										const { checkCachedStatus } = await import(
-											'@/services/torbox'
-										);
+										const { checkCachedStatus } =
+											await import('@/services/torbox');
 										const availableSet = new Set<string>();
 										for (let i = 0; i < newHashes.length; i += 100) {
 											const batch = newHashes.slice(i, i + 100);
@@ -1446,9 +1455,8 @@ function TorrentsPage() {
 
 					try {
 						if (rdKey && debridService === 'rd') {
-							const { checkAvailabilityByHashes } = await import(
-								'@/utils/availability'
-							);
+							const { checkAvailabilityByHashes } =
+								await import('@/utils/availability');
 							const availableSet = new Set<string>();
 
 							for (let i = 0; i < newHashes.length; i += 100) {
@@ -1711,6 +1719,32 @@ function TorrentsPage() {
 				handleAddMultipleHashesInTb(tbKey, hashes, async () => await refreshLibrary());
 			}
 		}
+		if (torrinBaseUrl && torrinApiKey && debridService === 'tr') {
+			const allHashes = [...hashes];
+			if (torrentFiles.length > 0) {
+				try {
+					const fileHashes = await Promise.all(
+						torrentFiles.map((file) => getHashOfTorrent(file))
+					);
+					allHashes.push(...(fileHashes.filter((h) => h !== undefined) as string[]));
+				} catch (error) {
+					toast.error(`Hash extraction failed: ${error}`);
+					return;
+				}
+			}
+			if (allHashes.length > 0) {
+				try {
+					for (const h of allHashes) {
+						const id = await addTorrinMagnet(torrinBaseUrl, torrinApiKey, h);
+						await selectTorrinFiles(torrinBaseUrl, torrinApiKey, id, 'all');
+					}
+					toast.success(`Added ${allHashes.length} to Torrin.`);
+					await refreshLibrary();
+				} catch (error) {
+					toast.error(`Torrin add failed: ${error}`);
+				}
+			}
+		}
 	}
 
 	const hasNoQueryParamsBut = (...params: string[]) =>
@@ -1835,6 +1869,7 @@ function TorrentsPage() {
 						hasRd={!!rdKey}
 						hasAd={!!adKey}
 						hasTb={!!tbKey}
+						hasTr={!!(torrinBaseUrl && torrinApiKey)}
 					/>
 					<LibraryActionButtons
 						onSelectShown={() => selectShown(currentPageData, setSelectedTorrents)}
@@ -1852,6 +1887,7 @@ function TorrentsPage() {
 						rdKey={rdKey}
 						adKey={adKey}
 						tbKey={tbKey}
+						trKey={torrinBaseUrl && torrinApiKey ? torrinApiKey : null}
 						showDedupe={
 							router.query.status === 'sametitle' ||
 							(!!titleFilter && filteredList.length > 1)
@@ -1899,6 +1935,8 @@ function TorrentsPage() {
 												rdKey={rdKey}
 												adKey={adKey}
 												tbKey={tbKey}
+												torrinBaseUrl={torrinBaseUrl}
+												torrinApiKey={torrinApiKey}
 												shouldDownloadMagnets={shouldDownloadMagnets}
 												hashGrouping={hashGrouping}
 												titleGrouping={getTitleGroupings(torrent.mediaType)}
@@ -1979,6 +2017,19 @@ function TorrentsPage() {
 															t,
 															tbKey,
 															setUserTorrentsList,
+															setSelectedTorrents
+														);
+													} else if (
+														t.id.startsWith('tr:') &&
+														torrinBaseUrl &&
+														torrinApiKey
+													) {
+														await handleShowInfoForTorrin(
+															t,
+															torrinBaseUrl,
+															torrinApiKey,
+															setUserTorrentsList,
+															torrentDB,
 															setSelectedTorrents
 														);
 													} else {

--- a/src/pages/movie/[imdbid]/index.tsx
+++ b/src/pages/movie/[imdbid]/index.tsx
@@ -3,11 +3,17 @@ import MovieSearchResults from '@/components/MovieSearchResults';
 import SearchControls from '@/components/SearchControls';
 import { showInfoForAD, showInfoForRD, showInfoForTB } from '@/components/showInfo';
 import { useLibraryCache } from '@/contexts/LibraryCacheContext';
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { useAvailabilityCheck } from '@/hooks/useAvailabilityCheck';
 import { useExternalSources } from '@/hooks/useExternalSources';
 import { useMassReport } from '@/hooks/useMassReport';
 import { useTorrentManagement } from '@/hooks/useTorrentManagement';
+import { useTorrinAvailability } from '@/hooks/useTorrinAvailability';
 import { SearchApiResponse, SearchResult, hasSubstantialTitle } from '@/services/mediasearch';
 import { TorrentInfoResponse } from '@/services/types';
 import UserTorrentDB from '@/torrent/db';
@@ -36,6 +42,7 @@ import { getStremioDetailUrl } from '@/utils/stremioLinks';
 import { castToastOptions, searchToastOptions } from '@/utils/toastOptions';
 import { generateTokenAndHash } from '@/utils/token';
 import { handleCastMovieTorBox } from '@/utils/torboxCastApiClient';
+import { handleCastMovieTorrin } from '@/utils/torrinCastApiClient';
 import { getMultipleTrackerStats } from '@/utils/trackerStats';
 import { withAuth } from '@/utils/withAuth';
 import { buildYearRegex } from '@/utils/yearFilter';
@@ -144,6 +151,7 @@ const MovieSearch: FunctionComponent = () => {
 	const [rdKey] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const torboxKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
 
 	// Library sync status - used to prevent auto-availability check while library is still loading
 	const { isFetching: isLibrarySyncing } = useLibraryCache();
@@ -181,7 +189,8 @@ const MovieSearch: FunctionComponent = () => {
 	const { fetchMovieFromExternalSource, getEnabledSources } = useExternalSources(
 		rdKey,
 		adKey,
-		torboxKey
+		torboxKey,
+		torrinApiKey
 	);
 
 	const {
@@ -204,7 +213,15 @@ const MovieSearch: FunctionComponent = () => {
 		sortByBiggest
 	);
 
-	const { handleMassReport } = useMassReport(rdKey, adKey, torboxKey, imdbid as string);
+	useTorrinAvailability(searchResults, setSearchResults);
+
+	const { handleMassReport } = useMassReport(
+		rdKey,
+		adKey,
+		torboxKey,
+		imdbid as string,
+		torrinApiKey
+	);
 
 	// Fetch movie info
 	useEffect(() => {
@@ -741,6 +758,19 @@ const MovieSearch: FunctionComponent = () => {
 		window.open(getStremioDetailUrl(imdbid as string));
 	}
 
+	async function handleCastTorrin(hash: string) {
+		await toast.promise(
+			handleCastMovieTorrin(imdbid as string, torrinBaseUrl!, torrinApiKey!, hash),
+			{
+				loading: 'Starting Torrin cast in Stremio...',
+				success: 'Cast started in Stremio',
+				error: 'Torrin cast failed in Stremio',
+			},
+			castToastOptions
+		);
+		window.open(getStremioDetailUrl(imdbid as string));
+	}
+
 	const getFirstAvailableRdTorrent = () => {
 		return filteredResults.find((r) => r.rdAvailable && !r.noVideos);
 	};
@@ -964,6 +994,9 @@ const MovieSearch: FunctionComponent = () => {
 						handleCast={handleCast}
 						handleCastTorBox={torboxKey ? handleCastTorBox : undefined}
 						handleCastAllDebrid={adKey ? handleCastAllDebrid : undefined}
+						handleCastTorrin={
+							torrinBaseUrl && torrinApiKey ? handleCastTorrin : undefined
+						}
 						handleCopyMagnet={(hash) =>
 							handleCopyOrDownloadMagnet(hash, shouldDownloadMagnets)
 						}

--- a/src/pages/show/[imdbid]/[seasonNum].tsx
+++ b/src/pages/show/[imdbid]/[seasonNum].tsx
@@ -3,11 +3,17 @@ import SearchTokens from '@/components/SearchTokens';
 import TvSearchResults from '@/components/TvSearchResults';
 import { showInfoForAD, showInfoForRD, showInfoForTB } from '@/components/showInfo';
 import { useLibraryCache } from '@/contexts/LibraryCacheContext';
-import { useAllDebridApiKey, useRealDebridAccessToken, useTorBoxAccessToken } from '@/hooks/auth';
+import {
+	useAllDebridApiKey,
+	useRealDebridAccessToken,
+	useTorBoxAccessToken,
+	useTorrinCreds,
+} from '@/hooks/auth';
 import { useAvailabilityCheck } from '@/hooks/useAvailabilityCheck';
 import { useExternalSources } from '@/hooks/useExternalSources';
 import { useMassReport } from '@/hooks/useMassReport';
 import { useTorrentManagement } from '@/hooks/useTorrentManagement';
+import { useTorrinAvailability } from '@/hooks/useTorrinAvailability';
 import { SearchApiResponse, SearchResult, hasSubstantialTitle } from '@/services/mediasearch';
 import { TorrentInfoResponse } from '@/services/types';
 import UserTorrentDB from '@/torrent/db';
@@ -42,6 +48,7 @@ import { getStremioDetailUrl } from '@/utils/stremioLinks';
 import { castToastOptions, searchToastOptions } from '@/utils/toastOptions';
 import { generateTokenAndHash } from '@/utils/token';
 import { handleCastTvShowTorBox } from '@/utils/torboxCastApiClient';
+import { handleCastTvShowTorrin } from '@/utils/torrinCastApiClient';
 import { getMultipleTrackerStats } from '@/utils/trackerStats';
 import { withAuth } from '@/utils/withAuth';
 import { AxiosError } from 'axios';
@@ -125,6 +132,7 @@ const TvSearch: FunctionComponent = () => {
 	const [rdKey] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const torboxKey = useTorBoxAccessToken();
+	const [torrinBaseUrl, torrinApiKey] = useTorrinCreds();
 
 	// Library sync status - used to prevent auto-availability check while library is still loading
 	const { isFetching: isLibrarySyncing } = useLibraryCache();
@@ -178,7 +186,8 @@ const TvSearch: FunctionComponent = () => {
 	const { fetchEpisodeFromExternalSource, getEnabledSources } = useExternalSources(
 		rdKey,
 		adKey,
-		torboxKey
+		torboxKey,
+		torrinApiKey
 	);
 
 	const {
@@ -201,7 +210,15 @@ const TvSearch: FunctionComponent = () => {
 		sortByMedian
 	);
 
-	const { handleMassReport } = useMassReport(rdKey, adKey, torboxKey, imdbid as string);
+	useTorrinAvailability(searchResults, setSearchResults);
+
+	const { handleMassReport } = useMassReport(
+		rdKey,
+		adKey,
+		torboxKey,
+		imdbid as string,
+		torrinApiKey
+	);
 
 	const expectedEpisodeCount = useMemo(
 		() =>
@@ -803,6 +820,21 @@ const TvSearch: FunctionComponent = () => {
 		);
 	}
 
+	async function handleCastTorrin(hash: string, fileIds: string[]) {
+		await toast.promise(
+			handleCastTvShowTorrin(imdbid as string, torrinBaseUrl!, torrinApiKey!, hash, fileIds),
+			{
+				loading: `Casting ${fileIds.length} episodes (Torrin)...`,
+				success: 'Casting succeeded.',
+				error: 'Casting failed.',
+			},
+			castToastOptions
+		);
+		window.open(
+			getStremioDetailUrl(imdbid as string, { season: String(seasonNum), episode: 1 })
+		);
+	}
+
 	// Helper function to find all complete season torrents (RD-available with matching episode count)
 	const getCompleteSeasonTorrents = () => {
 		const minEpisodes = Math.max(1, expectedEpisodeCount - 2);
@@ -1375,6 +1407,7 @@ const TvSearch: FunctionComponent = () => {
 				handleCast={handleCast}
 				handleCastTorBox={torboxKey ? handleCastTorBox : undefined}
 				handleCastAllDebrid={adKey ? handleCastAllDebrid : undefined}
+				handleCastTorrin={torrinBaseUrl && torrinApiKey ? handleCastTorrin : undefined}
 				handleCopyMagnet={(hash) => handleCopyOrDownloadMagnet(hash, shouldDownloadMagnets)}
 				checkServiceAvailability={checkServiceAvailability}
 				addRd={addRd}

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -5,12 +5,14 @@ import {
 	useTorBoxAccessToken,
 } from '@/hooks/auth';
 import Head from 'next/head';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 export default function StartPage() {
 	const router = useRouter();
-	const { loginWithRealDebrid, loginWithAllDebrid, loginWithTorbox } = useDebridLogin();
+	const { loginWithRealDebrid, loginWithAllDebrid, loginWithTorbox, loginWithTorrin } =
+		useDebridLogin();
 	const [rdToken] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
@@ -111,6 +113,30 @@ export default function StartPage() {
 						rel="noopener noreferrer"
 					>
 						Create an account with Torbox
+					</a>
+				</div>
+
+				{/* Torrin */}
+				<div className="flex flex-row">
+					<button
+						className="m-2 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+						onClick={loginWithTorrin}
+					>
+						Login with Torrin
+					</button>
+					<Link
+						className="m-2 rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+						href="/torrin/library"
+					>
+						Torrin Library
+					</Link>
+					<a
+						className="m-2 rounded bg-green-500 px-4 py-2 text-white hover:bg-green-600"
+						href="https://github.com/torrin-app/torrin"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Self-host Torrin
 					</a>
 				</div>
 

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -3,6 +3,7 @@ import {
 	useDebridLogin,
 	useRealDebridAccessToken,
 	useTorBoxAccessToken,
+	useTorrinCreds,
 } from '@/hooks/auth';
 import Head from 'next/head';
 import Link from 'next/link';
@@ -16,14 +17,15 @@ export default function StartPage() {
 	const [rdToken] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
+	const [, torrinKey] = useTorrinCreds();
 
 	// Redirect to index if already logged in
 	useEffect(() => {
-		const isLoggedIn = rdToken || adKey || tbKey;
+		const isLoggedIn = rdToken || adKey || tbKey || torrinKey;
 		if (isLoggedIn) {
 			router.push('/');
 		}
-	}, [rdToken, adKey, tbKey, router]);
+	}, [rdToken, adKey, tbKey, torrinKey, router]);
 
 	return (
 		<div className="flex h-screen flex-col items-center justify-center">

--- a/src/pages/start.tsx
+++ b/src/pages/start.tsx
@@ -17,15 +17,15 @@ export default function StartPage() {
 	const [rdToken] = useRealDebridAccessToken();
 	const adKey = useAllDebridApiKey();
 	const tbKey = useTorBoxAccessToken();
-	const [, torrinKey] = useTorrinCreds();
+	const [torrinBaseUrl, torrinKey] = useTorrinCreds();
 
 	// Redirect to index if already logged in
 	useEffect(() => {
-		const isLoggedIn = rdToken || adKey || tbKey || torrinKey;
+		const isLoggedIn = rdToken || adKey || tbKey || (torrinBaseUrl && torrinKey);
 		if (isLoggedIn) {
 			router.push('/');
 		}
-	}, [rdToken, adKey, tbKey, torrinKey, router]);
+	}, [rdToken, adKey, tbKey, torrinBaseUrl, torrinKey, router]);
 
 	return (
 		<div className="flex h-screen flex-col items-center justify-center">

--- a/src/pages/stremio-torrin/index.tsx
+++ b/src/pages/stremio-torrin/index.tsx
@@ -1,0 +1,179 @@
+import { CastSettingsPanel } from '@/components/CastSettingsPanel';
+import { useTorrinCastToken } from '@/hooks/torrinCastToken';
+import { withAuth } from '@/utils/withAuth';
+import { AlertTriangle, Cast, ClipboardList, EyeOff, Globe, Popcorn, Wand2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useState } from 'react';
+
+export function StremioTorrinPage() {
+	const dmmCastToken = useTorrinCastToken();
+	const [hasTorrinCredentials] = useState(() => {
+		if (typeof window !== 'undefined') {
+			return (
+				!!localStorage.getItem('torrin:apiKey') && !!localStorage.getItem('torrin:baseUrl')
+			);
+		}
+		return false;
+	});
+
+	if (!hasTorrinCredentials) {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 p-4">
+				<Head>
+					<title>DMM Cast for Torrin - Stremio</title>
+				</Head>
+				<div className="max-w-md rounded-lg border-2 border-red-500 bg-red-900/20 p-6 text-center">
+					<AlertTriangle className="mx-auto mb-4 h-12 w-12 text-red-400" />
+					<h1 className="mb-3 text-2xl font-bold text-red-400">Torrin Required</h1>
+					<p className="mb-4 text-gray-300">
+						You must be connected to a Torrin instance to use the Stremio Cast feature.
+					</p>
+					<Link
+						href="/torrin/login"
+						className="haptic-sm inline-block rounded border-2 border-sky-500 bg-sky-800/30 px-6 py-2 font-medium text-sky-100 transition-colors hover:bg-sky-700/50"
+					>
+						Connect Torrin
+					</Link>
+				</div>
+			</div>
+		);
+	}
+
+	if (!dmmCastToken) {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center bg-gray-900">
+				<h1 className="text-center text-xl text-white">
+					Debrid Media Manager is loading...
+				</h1>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex min-h-screen flex-col items-center justify-center bg-gray-900 p-4">
+			<Head>
+				<title>DMM Cast for Torrin - Stremio</title>
+			</Head>
+
+			<Image
+				width={200}
+				height={200}
+				src="https://static.debridmediamanager.com/dmmcast.png"
+				alt="logo"
+				className="mb-4"
+			/>
+			<h1 className="mb-4 text-2xl font-bold text-sky-400">DMM Cast for Torrin</h1>
+			<div className="flex flex-col items-center text-white">
+				<strong>Cast from any device to Stremio</strong>
+
+				{dmmCastToken && (
+					<div className="mb-4 mt-4 h-max text-center leading-8">
+						<Link
+							href={`stremio://${window.location.origin.replace(
+								/^https?:\/\//,
+								''
+							)}/api/stremio-tr/${dmmCastToken}/manifest.json`}
+							className="text-md haptic-sm m-1 rounded border-2 border-sky-500 bg-sky-800/30 px-4 py-2 font-medium text-gray-100 transition-colors hover:bg-sky-700/50"
+						>
+							<Wand2 className="mr-1 inline-block h-4 w-4 text-sky-400" />
+							Install
+						</Link>
+						<Link
+							href={`https://web.stremio.com/#/addons?addon=${encodeURIComponent(
+								`${window.location.origin}/api/stremio-tr/${dmmCastToken}/manifest.json`
+							)}`}
+							className="text-md haptic-sm m-1 rounded border-2 border-sky-500 bg-sky-800/30 px-4 py-2 font-medium text-gray-100 transition-colors hover:bg-sky-700/50"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							<Globe className="mr-1 inline-block h-4 w-4 text-blue-400" />
+							Install (web)
+						</Link>
+						<div className="mt-2 text-gray-300">
+							or copy this link and paste it in Stremio&apos;s search bar
+						</div>
+						<div className="mt-2 text-sm text-red-400">
+							<AlertTriangle className="mr-1 inline-block h-4 w-4 text-red-400" />
+							Warning: Never share this install URL with anyone. It is unique to your
+							account and sharing it could compromise your access.
+						</div>
+						<code className="mt-2 block w-full break-all rounded bg-gray-800 p-2 text-sm text-gray-300">
+							{window.location.origin}/api/stremio-tr/{dmmCastToken}/manifest.json
+						</code>
+
+						<div className="mt-4 border-t border-gray-700 pt-4">
+							<div className="mb-2 flex items-center justify-center text-sm text-gray-400">
+								<EyeOff className="mr-1 h-3 w-3" />
+								No Catalog Version (hides all catalogs from Stremio home)
+							</div>
+							<Link
+								href={`stremio://${window.location.origin.replace(
+									/^https?:\/\//,
+									''
+								)}/api/stremio-tr/${dmmCastToken}/no-catalog/manifest.json`}
+								className="haptic-sm m-1 rounded border border-gray-600 bg-gray-800/50 px-3 py-1 text-sm font-medium text-gray-300 transition-colors hover:bg-gray-700/50"
+							>
+								<Wand2 className="mr-1 inline-block h-3 w-3 text-gray-400" />
+								Install
+							</Link>
+							<Link
+								href={`https://web.stremio.com/#/addons?addon=${encodeURIComponent(
+									`${window.location.origin}/api/stremio-tr/${dmmCastToken}/no-catalog/manifest.json`
+								)}`}
+								className="haptic-sm m-1 rounded border border-gray-600 bg-gray-800/50 px-3 py-1 text-sm font-medium text-gray-300 transition-colors hover:bg-gray-700/50"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<Globe className="mr-1 inline-block h-3 w-3 text-gray-400" />
+								Install (web)
+							</Link>
+						</div>
+					</div>
+				)}
+
+				<div className="space-y-2 text-gray-300">
+					<div>1. Choose a Movie or TV Show in DMM</div>
+					<div>
+						2. Click the &quot;
+						<Cast className="inline-block h-3 w-3 text-sky-400" /> Cast&quot; button
+					</div>
+					<div>3. Stremio opens automatically to the movie/show</div>
+					<div>4. Your casted stream appears in the stream list</div>
+					<div>
+						5.{' '}
+						<span className="inline-flex items-center">
+							Enjoy! <Popcorn className="ml-1 inline-block h-4 w-4 text-yellow-500" />
+						</span>
+					</div>
+				</div>
+
+				<CastSettingsPanel service="tr" accentColor="sky" />
+			</div>
+
+			<div className="mt-6 flex gap-4">
+				{dmmCastToken && (
+					<Link
+						href="/stremio-torrin/manage"
+						className="haptic-sm rounded border-2 border-sky-500 bg-sky-800/30 px-4 py-2 text-sm font-medium text-sky-100 transition-colors hover:bg-sky-700/50"
+					>
+						<span className="inline-flex items-center">
+							<ClipboardList className="mr-1 h-4 w-4" />
+							Manage Casted Links
+						</span>
+					</Link>
+				)}
+				<Link
+					href="/"
+					className="haptic-sm rounded border-2 border-cyan-500 bg-cyan-900/30 px-4 py-2 text-sm font-medium text-cyan-100 transition-colors hover:bg-cyan-800/50"
+				>
+					Go Home
+				</Link>
+			</div>
+		</div>
+	);
+}
+
+export default dynamic(() => Promise.resolve(withAuth(StremioTorrinPage)), { ssr: false });

--- a/src/pages/stremio-torrin/manage.tsx
+++ b/src/pages/stremio-torrin/manage.tsx
@@ -1,0 +1,539 @@
+import Poster from '@/components/poster';
+import useLocalStorage from '@/hooks/localStorage';
+import { useTorrinCastToken } from '@/hooks/torrinCastToken';
+import { getStremioDetailUrl } from '@/utils/stremioLinks';
+import { withAuth } from '@/utils/withAuth';
+import { Eye, Trash2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+import Image from 'next/image';
+import Link from 'next/link';
+import ptt from 'parse-torrent-title';
+import { useEffect, useState } from 'react';
+import { flushSync } from 'react-dom';
+import { Toaster, toast } from 'react-hot-toast';
+
+interface CastedLink {
+	imdbId: string;
+	url: string;
+	hash: string;
+	size: number;
+	updatedAt: Date;
+}
+
+interface GroupedLinks {
+	[imdbId: string]: CastedLink[];
+}
+
+interface EpisodeInfo {
+	season: number;
+	episode: number;
+}
+
+interface MediaMetadata {
+	title: string;
+	type: 'movie' | 'show';
+}
+
+export function TorrinManagePage() {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	useTorrinCastToken();
+	const [groupedLinks, setGroupedLinks] = useState<GroupedLinks>({});
+	const [loading, setLoading] = useState(true);
+	const [selectedLinks, setSelectedLinks] = useState<Set<string>>(new Set());
+	const [mediaInfo, setMediaInfo] = useState<Record<string, MediaMetadata>>({});
+
+	const creds = () =>
+		`baseUrl=${encodeURIComponent(baseUrl ?? '')}&apiKey=${encodeURIComponent(apiKey ?? '')}`;
+
+	const getEpisodeInfo = (imdbId: string): EpisodeInfo | null => {
+		const parts = imdbId.split(':');
+		if (parts.length === 3) {
+			return {
+				season: parseInt(parts[1]),
+				episode: parseInt(parts[2]),
+			};
+		}
+		return null;
+	};
+
+	useEffect(() => {
+		const fetchLinks = async () => {
+			if (!baseUrl || !apiKey) {
+				setLoading(false);
+				return;
+			}
+
+			try {
+				const response = await fetch(`/api/stremio-tr/links?${creds()}`);
+				if (!response.ok) throw new Error('Failed to fetch links');
+				const data = await response.json();
+				const links = data.links || [];
+
+				const grouped = links.reduce((acc: GroupedLinks, link: CastedLink) => {
+					const baseImdbId = link.imdbId.split(':')[0];
+					if (!acc[baseImdbId]) {
+						acc[baseImdbId] = [];
+					}
+					acc[baseImdbId].push(link);
+					return acc;
+				}, {});
+
+				Object.keys(grouped).forEach((imdbId) => {
+					grouped[imdbId].sort((a: CastedLink, b: CastedLink) => {
+						const aEpisode = getEpisodeInfo(a.imdbId);
+						const bEpisode = getEpisodeInfo(b.imdbId);
+						if (!aEpisode && !bEpisode) return 0;
+						if (!aEpisode) return -1;
+						if (!bEpisode) return 1;
+						return (
+							aEpisode.season * 1000 +
+							aEpisode.episode -
+							(bEpisode.season * 1000 + bEpisode.episode)
+						);
+					});
+				});
+
+				setGroupedLinks(grouped);
+			} catch (error) {
+				console.error(error);
+				toast.error('Failed to fetch casted links.');
+			} finally {
+				setLoading(false);
+			}
+		};
+
+		fetchLinks();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [baseUrl, apiKey]);
+
+	useEffect(() => {
+		const imdbIdsToFetch = Object.keys(groupedLinks).filter((imdbId) => !mediaInfo[imdbId]);
+		if (imdbIdsToFetch.length === 0) return;
+
+		let active = true;
+
+		const loadMetadata = async () => {
+			const results = await Promise.all(
+				imdbIdsToFetch.map(async (imdbId) => {
+					const links = groupedLinks[imdbId] ?? [];
+					const isShow = links.some((link) => link.imdbId.split(':').length === 3);
+					const endpoint = isShow ? '/api/info/show' : '/api/info/movie';
+					const mediaType: MediaMetadata['type'] = isShow ? 'show' : 'movie';
+					try {
+						const response = await fetch(`${endpoint}?imdbid=${imdbId}`);
+						if (!response.ok) {
+							throw new Error(
+								`Metadata request failed with status ${response.status}`
+							);
+						}
+						const data = await response.json();
+						const title =
+							typeof data.title === 'string' && data.title.trim()
+								? data.title.trim()
+								: imdbId;
+						return {
+							imdbId,
+							info: {
+								title,
+								type: mediaType,
+							},
+						};
+					} catch (error) {
+						return {
+							imdbId,
+							info: {
+								title: imdbId,
+								type: mediaType,
+							},
+						};
+					}
+				})
+			);
+
+			if (!active) return;
+
+			setMediaInfo((prev) => {
+				const updated = { ...prev };
+				for (const result of results) {
+					updated[result.imdbId] = result.info;
+				}
+				return updated;
+			});
+		};
+
+		void loadMetadata();
+
+		return () => {
+			active = false;
+		};
+	}, [groupedLinks, mediaInfo]);
+
+	const getStremioUrl = (link: CastedLink): string => {
+		const baseImdbId = link.imdbId.split(':')[0];
+		const filename = link.url.split('/').pop() || '';
+		const info = ptt.parse(filename);
+		const seasonNumber = info.season;
+		const episodeNumber = info.episode;
+
+		if (seasonNumber !== undefined && episodeNumber !== undefined) {
+			return getStremioDetailUrl(baseImdbId, {
+				season: seasonNumber,
+				episode: episodeNumber,
+			});
+		}
+		return getStremioDetailUrl(baseImdbId);
+	};
+
+	const handleDelete = async (link: CastedLink) => {
+		try {
+			if (!baseUrl || !apiKey) return;
+
+			const response = await fetch('/api/stremio-tr/deletelink', {
+				method: 'DELETE',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					baseUrl,
+					apiKey,
+					imdbId: link.imdbId,
+					hash: link.hash,
+				}),
+			});
+
+			if (!response.ok) throw new Error('Failed to delete link');
+
+			const baseImdbId = link.imdbId.split(':')[0];
+			let removedImdbId: string | null = null;
+			flushSync(() => {
+				setGroupedLinks((prev) => {
+					const newGrouped = { ...prev };
+					newGrouped[baseImdbId] = newGrouped[baseImdbId].filter(
+						(l) => l.url !== link.url
+					);
+					if (newGrouped[baseImdbId].length === 0) {
+						delete newGrouped[baseImdbId];
+						removedImdbId = baseImdbId;
+					}
+					return newGrouped;
+				});
+			});
+
+			if (removedImdbId) {
+				const imdbIdToRemove = removedImdbId;
+				setMediaInfo((prev) => {
+					if (!(imdbIdToRemove in prev)) {
+						return prev;
+					}
+					const { [imdbIdToRemove]: _removed, ...rest } = prev;
+					return rest;
+				});
+			}
+
+			toast.success('Link deleted from Stremio list.');
+		} catch (error) {
+			console.error(error);
+			toast.error('Failed to delete Stremio link.');
+		}
+	};
+
+	const handleDeleteSelected = async () => {
+		if (selectedLinks.size === 0) return;
+
+		try {
+			const deletePromises = Array.from(selectedLinks).map(async (url) => {
+				let link: CastedLink | null = null;
+				for (const links of Object.values(groupedLinks)) {
+					link = links.find((l) => l.url === url) || null;
+					if (link) break;
+				}
+				if (!link) return;
+
+				const response = await fetch('/api/stremio-tr/deletelink', {
+					method: 'DELETE',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({
+						baseUrl,
+						apiKey,
+						imdbId: link.imdbId,
+						hash: link.hash,
+					}),
+				});
+
+				if (!response.ok) throw new Error('Failed to delete link');
+				return url;
+			});
+
+			const deletedUrls = (await Promise.all(deletePromises)).filter(
+				(url): url is string => typeof url === 'string'
+			);
+
+			const removedImdbIds: string[] = [];
+			flushSync(() => {
+				setGroupedLinks((prev) => {
+					const newGrouped = { ...prev };
+					Object.keys(newGrouped).forEach((imdbId) => {
+						newGrouped[imdbId] = newGrouped[imdbId].filter(
+							(link) => !deletedUrls.includes(link.url)
+						);
+						if (newGrouped[imdbId].length === 0) {
+							delete newGrouped[imdbId];
+							removedImdbIds.push(imdbId);
+						}
+					});
+					return newGrouped;
+				});
+			});
+
+			if (removedImdbIds.length > 0) {
+				setMediaInfo((prev) => {
+					const updated = { ...prev };
+					for (const imdbId of removedImdbIds) {
+						delete updated[imdbId];
+					}
+					return updated;
+				});
+			}
+
+			setSelectedLinks(new Set());
+			toast.success('Deleted selected Stremio links.');
+		} catch (error) {
+			console.error(error);
+			toast.error('Failed to delete selected Stremio links.');
+		}
+	};
+
+	const toggleLinkSelection = (url: string) => {
+		setSelectedLinks((prev) => {
+			const newSet = new Set(prev);
+			if (newSet.has(url)) {
+				newSet.delete(url);
+			} else {
+				newSet.add(url);
+			}
+			return newSet;
+		});
+	};
+
+	const toggleGroupSelection = (imdbId: string) => {
+		const links = groupedLinks[imdbId];
+		const urls = links.map((link) => link.url);
+		const allSelected = urls.every((url) => selectedLinks.has(url));
+
+		setSelectedLinks((prev) => {
+			const newSet = new Set(prev);
+			if (allSelected) {
+				urls.forEach((url) => newSet.delete(url));
+			} else {
+				urls.forEach((url) => newSet.add(url));
+			}
+			return newSet;
+		});
+	};
+
+	const formatSize = (size: number) => {
+		const gb = size / 1024;
+		return `${gb.toFixed(2)} GB`;
+	};
+
+	const getFilename = (url: string) => {
+		try {
+			return decodeURIComponent(url.split('/').pop() || '');
+		} catch (error) {
+			return 'Unknown file';
+		}
+	};
+
+	const deriveTitleFromLinks = (links: CastedLink[]): string | null => {
+		for (const link of links) {
+			const filename = getFilename(link.url);
+			if (!filename || filename === 'Unknown file') {
+				continue;
+			}
+			const parsed = ptt.parse(filename);
+			const candidate =
+				typeof parsed.title === 'string' ? parsed.title.replace(/\./g, ' ').trim() : '';
+			if (candidate) {
+				return candidate;
+			}
+		}
+		return null;
+	};
+
+	const formatEpisodeLabel = (imdbId: string) => {
+		const episodeInfo = getEpisodeInfo(imdbId);
+		if (episodeInfo) {
+			return `S${episodeInfo.season.toString().padStart(2, '0')}E${episodeInfo.episode.toString().padStart(2, '0')}`;
+		}
+		return null;
+	};
+
+	if (!baseUrl || !apiKey) {
+		return (
+			<div className="flex min-h-screen flex-col items-center justify-center bg-gray-900">
+				<h1 className="text-center text-xl text-white">
+					Debrid Media Manager is loading...
+				</h1>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex min-h-screen flex-col items-center bg-gray-900 p-4">
+			<Head>
+				<title>DMM Cast Torrin - Manage Casted Links</title>
+			</Head>
+			<Image
+				width={100}
+				height={100}
+				src="https://static.debridmediamanager.com/dmmcast.png"
+				alt="logo"
+				className="mb-4"
+			/>
+			<Toaster position="bottom-right" />
+
+			{selectedLinks.size > 0 && (
+				<div className="fixed left-0 right-0 top-0 z-50 flex justify-center bg-gray-900/95 p-4 backdrop-blur">
+					<button
+						onClick={handleDeleteSelected}
+						className="haptic-sm rounded bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
+					>
+						Delete Selected ({selectedLinks.size})
+					</button>
+				</div>
+			)}
+
+			<div className="mb-6 flex flex-col items-center gap-4">
+				<h1 className="text-xl font-bold text-white">
+					DMM Cast Torrin - Manage Casted Links
+				</h1>
+			</div>
+
+			{loading ? (
+				<p className="text-white">Loading...</p>
+			) : Object.keys(groupedLinks).length === 0 ? (
+				<p className="text-white">No casted links found</p>
+			) : (
+				<div className="grid w-full max-w-6xl gap-6 md:grid-cols-2 lg:grid-cols-3">
+					{Object.entries(groupedLinks).map(([imdbId, links]) => {
+						const allSelected = links.every((link) => selectedLinks.has(link.url));
+						const someSelected = links.some((link) => selectedLinks.has(link.url));
+						const metadata = mediaInfo[imdbId];
+						const derivedTitle = deriveTitleFromLinks(links);
+						const displayTitle = metadata?.title ?? derivedTitle ?? imdbId;
+						const isShowGroup =
+							metadata?.type === 'show' ||
+							links.some((link) => link.imdbId.split(':').length === 3);
+						return (
+							<div key={imdbId} className="rounded-lg bg-gray-800 p-4">
+								<div className="mb-4 flex items-center justify-between">
+									<label className="flex cursor-pointer items-center gap-2">
+										<input
+											type="checkbox"
+											checked={allSelected}
+											ref={(input) => {
+												if (input) {
+													input.indeterminate =
+														someSelected && !allSelected;
+												}
+											}}
+											onChange={() => toggleGroupSelection(imdbId)}
+											className="h-4 w-4 rounded border-gray-300 bg-gray-700 text-sky-600 focus:ring-sky-500"
+										/>
+										<span className="text-sm font-medium text-white">
+											Select All
+										</span>
+									</label>
+									<Link
+										href={`/x/${imdbId}`}
+										className="haptic-sm rounded bg-sky-600 px-3 py-1 text-sm text-white hover:bg-sky-700"
+										title={`Cast other torrents for ${displayTitle}`}
+										aria-label={`Cast other torrents for ${displayTitle}`}
+									>
+										Cast other torrents
+									</Link>
+								</div>
+								<div className="mb-4 flex justify-center">
+									<button
+										type="button"
+										onClick={() => toggleGroupSelection(imdbId)}
+										aria-pressed={allSelected}
+										aria-label={`Toggle selection for ${isShowGroup ? 'show' : 'movie'} ${displayTitle}`}
+										className="group flex w-full max-w-[220px] flex-col items-center focus:outline-none"
+									>
+										<Poster imdbId={imdbId} title={displayTitle} />
+										<span className="mt-2 w-full text-center text-sm font-semibold text-gray-100 group-hover:text-white">
+											{displayTitle}
+										</span>
+									</button>
+								</div>
+								<div className="max-h-[300px] space-y-2 overflow-y-auto">
+									{links.map((link) => {
+										const episodeLabel = formatEpisodeLabel(link.imdbId);
+										return (
+											<div
+												key={link.url}
+												className="flex items-center justify-between rounded bg-gray-700 p-2"
+											>
+												<div className="mr-2 flex min-w-0 flex-1 items-center gap-2">
+													<input
+														type="checkbox"
+														checked={selectedLinks.has(link.url)}
+														onChange={() =>
+															toggleLinkSelection(link.url)
+														}
+														className="h-4 w-4 rounded border-gray-300 bg-gray-600 text-sky-600 focus:ring-sky-500"
+													/>
+													<div className="flex min-w-0 flex-1 flex-col">
+														{episodeLabel && (
+															<span className="text-sm font-medium text-sky-300">
+																{episodeLabel}
+															</span>
+														)}
+														<span className="break-all text-sm text-gray-300">
+															{getFilename(link.url)}
+														</span>
+														<span className="text-xs text-gray-400">
+															{formatSize(link.size)}
+														</span>
+													</div>
+												</div>
+												<div className="flex shrink-0 gap-2">
+													<a
+														href={getStremioUrl(link)}
+														className="haptic-sm rounded bg-cyan-600 px-3 py-1 text-sm text-white hover:bg-cyan-700"
+													>
+														<Eye className="h-4 w-4" />
+													</a>
+													<button
+														onClick={() => handleDelete(link)}
+														className="haptic-sm rounded bg-red-600 px-3 py-1 text-sm text-white hover:bg-red-700"
+													>
+														<Trash2 className="h-4 w-4" />
+													</button>
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			)}
+
+			<Link
+				href="/stremio-torrin"
+				className="haptic-sm mt-6 rounded border-2 border-cyan-500 bg-cyan-900/30 px-4 py-2 text-sm font-medium text-cyan-100 transition-colors hover:bg-cyan-800/50"
+			>
+				Back to Stremio Torrin
+			</Link>
+		</div>
+	);
+}
+
+export default dynamic(() => Promise.resolve(withAuth(TorrinManagePage)), { ssr: false });

--- a/src/pages/torrin/library.tsx
+++ b/src/pages/torrin/library.tsx
@@ -1,0 +1,147 @@
+import useLocalStorage from '@/hooks/localStorage';
+import {
+	deleteTorrinTorrent,
+	getTorrinTorrentInfo,
+	getTorrinTorrentsList,
+	unrestrictTorrinLink,
+} from '@/services/torrin';
+import { UserTorrentResponse } from '@/services/types';
+import { Loader2, Play, RefreshCw, Trash2 } from 'lucide-react';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+
+function fmtSize(bytes: number): string {
+	if (!bytes) return '';
+	const gb = bytes / 1024 ** 3;
+	return gb >= 1 ? `${gb.toFixed(2)} GB` : `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+export default function TorrinLibraryPage() {
+	const [baseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [apiKey] = useLocalStorage<string>('torrin:apiKey');
+	const [torrents, setTorrents] = useState<UserTorrentResponse[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [busy, setBusy] = useState<string | null>(null);
+
+	const refresh = useCallback(async () => {
+		if (!baseUrl || !apiKey) return;
+		setLoading(true);
+		try {
+			const { data } = await getTorrinTorrentsList(baseUrl, apiKey, 1000, 1);
+			setTorrents(data);
+		} catch (e: any) {
+			toast.error(`Torrin: ${e?.message ?? 'failed to load library'}`);
+		} finally {
+			setLoading(false);
+		}
+	}, [baseUrl, apiKey]);
+
+	useEffect(() => {
+		refresh();
+	}, [refresh]);
+
+	const play = async (t: UserTorrentResponse) => {
+		if (!baseUrl || !apiKey) return;
+		setBusy(t.id);
+		try {
+			const info = await getTorrinTorrentInfo(baseUrl, apiKey, t.id);
+			const link = info.links?.[0];
+			if (!link) throw new Error('no link available');
+			const res = await unrestrictTorrinLink(baseUrl, apiKey, link);
+			window.open(res.download, '_blank');
+		} catch (e: any) {
+			toast.error(`Torrin: ${e?.message ?? 'could not get stream link'}`);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	const remove = async (id: string) => {
+		if (!baseUrl || !apiKey) return;
+		setBusy(id);
+		try {
+			await deleteTorrinTorrent(baseUrl, apiKey, id);
+			setTorrents((prev) => prev.filter((t) => t.id !== id));
+		} catch (e: any) {
+			toast.error(`Torrin: ${e?.message ?? 'could not delete'}`);
+		} finally {
+			setBusy(null);
+		}
+	};
+
+	if (!baseUrl || !apiKey) {
+		return (
+			<div className="flex h-screen flex-col items-center justify-center">
+				<p className="mb-4">Connect Torrin first.</p>
+				<Link href="/torrin/login" className="rounded bg-blue-500 px-4 py-2 text-white">
+					Connect Torrin
+				</Link>
+			</div>
+		);
+	}
+
+	return (
+		<div className="mx-auto max-w-4xl p-4">
+			<Head>
+				<title>Debrid Media Manager - Torrin Library</title>
+			</Head>
+			<div className="mb-4 flex items-center justify-between">
+				<h1 className="text-2xl font-bold">Torrin Library</h1>
+				<button
+					onClick={refresh}
+					className="inline-flex items-center gap-1 rounded bg-blue-500 px-3 py-1 text-sm text-white hover:bg-blue-600"
+				>
+					<RefreshCw className="h-4 w-4" /> Refresh
+				</button>
+			</div>
+			{loading ? (
+				<div className="flex justify-center p-8">
+					<Loader2 className="h-6 w-6 animate-spin" />
+				</div>
+			) : torrents.length === 0 ? (
+				<p className="text-center text-gray-400">No torrents in your Torrin library yet.</p>
+			) : (
+				<div className="space-y-2">
+					{torrents.map((t) => (
+						<div
+							key={t.id}
+							className="flex items-center gap-2 rounded border border-gray-700 p-2"
+						>
+							<div className="min-w-0 flex-1">
+								<div className="truncate text-sm">{t.filename}</div>
+								<div className="text-xs text-gray-400">
+									{fmtSize(t.bytes)} · {t.status}
+									{t.status !== 'downloaded' && t.progress != null
+										? ` ${t.progress}%`
+										: ''}
+								</div>
+							</div>
+							<button
+								onClick={() => play(t)}
+								disabled={busy === t.id || t.status !== 'downloaded'}
+								className="rounded border-2 border-green-500 bg-green-900/30 p-1 text-green-100 disabled:opacity-40"
+								title="Play"
+							>
+								{busy === t.id ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Play className="h-4 w-4" />
+								)}
+							</button>
+							<button
+								onClick={() => remove(t.id)}
+								disabled={busy === t.id}
+								className="rounded border-2 border-red-500 bg-red-900/30 p-1 text-red-100 disabled:opacity-40"
+								title="Delete"
+							>
+								<Trash2 className="h-4 w-4" />
+							</button>
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/pages/torrin/login.tsx
+++ b/src/pages/torrin/login.tsx
@@ -1,0 +1,84 @@
+import useLocalStorage from '@/hooks/localStorage';
+import { getTorrinUser } from '@/services/torrin';
+import { getSafeRedirectPath } from '@/utils/router';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+export default function TorrinLoginPage() {
+	const router = useRouter();
+	const [, setBaseUrl] = useLocalStorage<string>('torrin:baseUrl');
+	const [, setApiKey] = useLocalStorage<string>('torrin:apiKey');
+	const [inputBaseUrl, setInputBaseUrl] = useState('');
+	const [inputApiKey, setInputApiKey] = useState('');
+	const [error, setError] = useState('');
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		setError('');
+		const baseUrl = inputBaseUrl.trim().replace(/\/+$/, '');
+		try {
+			await getTorrinUser(baseUrl, inputApiKey.trim());
+			setBaseUrl(baseUrl);
+			setApiKey(inputApiKey.trim());
+			const redirectPath = getSafeRedirectPath(router.query.redirect, '/');
+			await router.replace(redirectPath);
+		} catch (err: any) {
+			setError(
+				`API Error: ${err.response?.data?.error || err.message || 'Could not validate credentials'}. Status: ${err.response?.status || 'unknown'}`
+			);
+		}
+	};
+
+	return (
+		<div className="flex h-screen flex-col items-center justify-center">
+			<Head>
+				<title>Debrid Media Manager - Torrin Login</title>
+			</Head>
+			<div className="w-full max-w-md space-y-4 p-4">
+				<h1 className="text-center text-2xl font-bold">Connect Torrin</h1>
+				<p className="text-center text-sm text-gray-400">
+					Torrin is a self-hostable, open-source debrid service. Enter your instance URL
+					and API key.
+				</p>
+				{error && <p className="text-center text-red-500">{error}</p>}
+				<form onSubmit={handleSubmit} className="space-y-4">
+					<div>
+						<label htmlFor="baseUrl" className="block text-sm font-medium">
+							Instance URL
+						</label>
+						<input
+							type="url"
+							id="baseUrl"
+							value={inputBaseUrl}
+							onChange={(e) => setInputBaseUrl(e.target.value)}
+							className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+							placeholder="https://your-torrin.example.com"
+							required
+						/>
+					</div>
+					<div>
+						<label htmlFor="apiKey" className="block text-sm font-medium">
+							API Key
+						</label>
+						<input
+							type="text"
+							id="apiKey"
+							value={inputApiKey}
+							onChange={(e) => setInputApiKey(e.target.value)}
+							className="mt-1 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+							placeholder="Enter your Torrin API key"
+							required
+						/>
+					</div>
+					<button
+						type="submit"
+						className="w-full rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+					>
+						Save &amp; Connect
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/src/pages/torrin/login.tsx
+++ b/src/pages/torrin/login.tsx
@@ -9,7 +9,7 @@ export default function TorrinLoginPage() {
 	const router = useRouter();
 	const [, setBaseUrl] = useLocalStorage<string>('torrin:baseUrl');
 	const [, setApiKey] = useLocalStorage<string>('torrin:apiKey');
-	const [inputBaseUrl, setInputBaseUrl] = useState('');
+	const [inputBaseUrl, setInputBaseUrl] = useState('https://torrin.app');
 	const [inputApiKey, setInputApiKey] = useState('');
 	const [error, setError] = useState('');
 

--- a/src/pages/torrin/login.tsx
+++ b/src/pages/torrin/login.tsx
@@ -62,7 +62,7 @@ export default function TorrinLoginPage() {
 							API Key
 						</label>
 						<input
-							type="text"
+							type="password"
 							id="apiKey"
 							value={inputApiKey}
 							onChange={(e) => setInputApiKey(e.target.value)}

--- a/src/services/database/index.ts
+++ b/src/services/database/index.ts
@@ -14,6 +14,7 @@ import { SearchService } from './search';
 import { StreamHealthService } from './streamHealth';
 import { TorBoxCastService } from './torboxCast';
 import { TorrentSnapshotService } from './torrentSnapshot';
+import { TorrinCastService } from './torrinCast';
 import { ZurgKeysService } from './zurgKeys';
 
 export {
@@ -33,5 +34,6 @@ export {
 	StreamHealthService,
 	TorBoxCastService,
 	TorrentSnapshotService,
+	TorrinCastService,
 	ZurgKeysService,
 };

--- a/src/services/database/torrinCast.test.ts
+++ b/src/services/database/torrinCast.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { TorrinCastService } from './torrinCast';
+
+const prismaMock = vi.hoisted(() => ({
+	torrinCastProfile: {
+		upsert: vi.fn(),
+		findUnique: vi.fn(),
+	},
+	torrinCast: {
+		findFirst: vi.fn(),
+		findMany: vi.fn(),
+		upsert: vi.fn(),
+		delete: vi.fn(),
+	},
+}));
+
+vi.mock('./client', () => ({
+	DatabaseClient: class {
+		prisma = prismaMock;
+	},
+}));
+
+describe('TorrinCastService', () => {
+	let service: TorrinCastService;
+
+	beforeEach(() => {
+		service = new TorrinCastService();
+		Object.values(prismaMock.torrinCastProfile).forEach((fn) => (fn as Mock).mockReset());
+		Object.values(prismaMock.torrinCast).forEach((fn) => (fn as Mock).mockReset());
+	});
+
+	describe('saveCastProfile', () => {
+		it('upserts a profile with baseUrl + apiKey and all fields', async () => {
+			prismaMock.torrinCastProfile.upsert.mockResolvedValue({});
+
+			await service.saveCastProfile('u1', 'https://tr.test', 'key1', 10, 5, 3, true);
+
+			expect(prismaMock.torrinCastProfile.upsert).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { userId: 'u1' },
+					create: expect.objectContaining({
+						baseUrl: 'https://tr.test',
+						apiKey: 'key1',
+						movieMaxSize: 10,
+						episodeMaxSize: 5,
+						otherStreamsLimit: 3,
+						hideCastOption: true,
+					}),
+				})
+			);
+		});
+	});
+
+	describe('getCastProfile', () => {
+		it('returns the stored profile', async () => {
+			prismaMock.torrinCastProfile.findUnique.mockResolvedValue({
+				baseUrl: 'https://tr.test',
+				apiKey: 'key',
+				movieMaxSize: 0,
+				episodeMaxSize: 0,
+				otherStreamsLimit: 5,
+				hideCastOption: false,
+			});
+
+			const result = await service.getCastProfile('u1');
+			expect(result).toMatchObject({ baseUrl: 'https://tr.test', apiKey: 'key' });
+		});
+	});
+
+	describe('saveCast', () => {
+		it('upserts a cast row with the link and size as BigInt', async () => {
+			prismaMock.torrinCast.upsert.mockResolvedValue({});
+
+			await service.saveCast('tt1', 'u1', 'hash', 'https://url', 'https://link', 500);
+
+			expect(prismaMock.torrinCast.upsert).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: { imdbId_userId_hash: { imdbId: 'tt1', userId: 'u1', hash: 'hash' } },
+					create: expect.objectContaining({
+						link: 'https://link',
+						url: 'https://url',
+						size: BigInt(500),
+					}),
+				})
+			);
+		});
+	});
+
+	describe('fetchCastedMovies', () => {
+		it('returns imdbIds excluding shows', async () => {
+			prismaMock.torrinCast.findMany.mockResolvedValue([
+				{ imdbId: 'tt1' },
+				{ imdbId: 'tt2' },
+			]);
+
+			const result = await service.fetchCastedMovies('u1');
+			expect(result).toEqual(['tt1', 'tt2']);
+			expect(prismaMock.torrinCast.findMany).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: expect.objectContaining({
+						imdbId: { not: { contains: ':' } },
+					}),
+				})
+			);
+		});
+	});
+
+	describe('fetchCastedShows', () => {
+		it('returns unique base imdbIds for shows', async () => {
+			prismaMock.torrinCast.findMany.mockResolvedValue([
+				{ imdbId: 'tt9:1:1' },
+				{ imdbId: 'tt9:1:2' },
+				{ imdbId: 'tt8:1:1' },
+			]);
+
+			const result = await service.fetchCastedShows('u1');
+			expect(result).toEqual(['tt9', 'tt8']);
+		});
+	});
+
+	describe('getUserCastStreams', () => {
+		it('maps rows to streams with a derived filename', async () => {
+			prismaMock.torrinCast.findMany.mockResolvedValue([
+				{
+					url: 'https://files/My.Movie.mkv',
+					link: 'https://link',
+					size: BigInt(1024),
+					hash: 'h1',
+				},
+			]);
+
+			const result = await service.getUserCastStreams('tt1', 'u1');
+			expect(result).toEqual([
+				{
+					url: 'https://files/My.Movie.mkv',
+					link: 'https://link',
+					size: 1024,
+					filename: 'My.Movie.mkv',
+					hash: 'h1',
+				},
+			]);
+		});
+
+		it('drops rows without a link', async () => {
+			prismaMock.torrinCast.findMany.mockResolvedValue([
+				{ url: 'https://files/a.mkv', link: null, size: BigInt(1), hash: 'h1' },
+			]);
+
+			const result = await service.getUserCastStreams('tt1', 'u1');
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('deleteCastedLink', () => {
+		it('deletes by composite key', async () => {
+			prismaMock.torrinCast.delete.mockResolvedValue({});
+
+			await service.deleteCastedLink('tt1', 'u1', 'hash');
+
+			expect(prismaMock.torrinCast.delete).toHaveBeenCalledWith({
+				where: { imdbId_userId_hash: { imdbId: 'tt1', userId: 'u1', hash: 'hash' } },
+			});
+		});
+
+		it('wraps delete errors', async () => {
+			prismaMock.torrinCast.delete.mockRejectedValue(new Error('nope'));
+			await expect(service.deleteCastedLink('tt1', 'u1', 'hash')).rejects.toThrow(
+				'Failed to delete casted link: nope'
+			);
+		});
+	});
+});

--- a/src/services/database/torrinCast.test.ts
+++ b/src/services/database/torrinCast.test.ts
@@ -71,7 +71,15 @@ describe('TorrinCastService', () => {
 		it('upserts a cast row with the link and size as BigInt', async () => {
 			prismaMock.torrinCast.upsert.mockResolvedValue({});
 
-			await service.saveCast('tt1', 'u1', 'hash', 'https://url', 'https://link', 500);
+			await service.saveCast(
+				'tt1',
+				'u1',
+				'hash',
+				'https://url',
+				'https://link',
+				500,
+				'https://tr.test'
+			);
 
 			expect(prismaMock.torrinCast.upsert).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -80,6 +88,7 @@ describe('TorrinCastService', () => {
 						link: 'https://link',
 						url: 'https://url',
 						size: BigInt(500),
+						baseUrl: 'https://tr.test',
 					}),
 				})
 			);

--- a/src/services/database/torrinCast.ts
+++ b/src/services/database/torrinCast.ts
@@ -155,7 +155,8 @@ export class TorrinCastService extends DatabaseClient {
 		hash: string,
 		url: string,
 		link: string,
-		fileSize: number
+		fileSize: number,
+		baseUrl: string
 	): Promise<void> {
 		await this.prisma.torrinCast.upsert({
 			where: {
@@ -170,6 +171,7 @@ export class TorrinCastService extends DatabaseClient {
 				link: link,
 				url: url,
 				size: BigInt(fileSize),
+				baseUrl: baseUrl,
 			},
 			create: {
 				imdbId: imdbId,
@@ -178,6 +180,7 @@ export class TorrinCastService extends DatabaseClient {
 				link: link,
 				url: url,
 				size: BigInt(fileSize),
+				baseUrl: baseUrl,
 			},
 		});
 	}
@@ -354,6 +357,7 @@ export class TorrinCastService extends DatabaseClient {
 	public async getOtherStreams(
 		imdbId: string,
 		userId: string,
+		baseUrl: string,
 		limit: number = 5,
 		maxSize?: number
 	): Promise<
@@ -373,6 +377,7 @@ export class TorrinCastService extends DatabaseClient {
 		const otherCastItems = await this.prisma.torrinCast.findMany({
 			where: {
 				imdbId: imdbId,
+				baseUrl: baseUrl,
 				link: {
 					not: null,
 				},

--- a/src/services/database/torrinCast.ts
+++ b/src/services/database/torrinCast.ts
@@ -1,0 +1,413 @@
+import { DatabaseClient } from './client';
+
+interface LatestCast {
+	url: string;
+	link: string;
+}
+
+export class TorrinCastService extends DatabaseClient {
+	public async saveCastProfile(
+		userId: string,
+		baseUrl: string,
+		apiKey: string,
+		movieMaxSize?: number,
+		episodeMaxSize?: number,
+		otherStreamsLimit?: number,
+		hideCastOption?: boolean
+	) {
+		return this.prisma.torrinCastProfile.upsert({
+			where: {
+				userId: userId,
+			},
+			update: {
+				baseUrl,
+				apiKey,
+				...(movieMaxSize !== undefined && { movieMaxSize }),
+				...(episodeMaxSize !== undefined && { episodeMaxSize }),
+				...(otherStreamsLimit !== undefined && { otherStreamsLimit }),
+				...(hideCastOption !== undefined && { hideCastOption }),
+				updatedAt: new Date(),
+			},
+			create: {
+				userId: userId,
+				baseUrl,
+				apiKey,
+				movieMaxSize: movieMaxSize ?? 0,
+				episodeMaxSize: episodeMaxSize ?? 0,
+				otherStreamsLimit: otherStreamsLimit ?? 5,
+				hideCastOption: hideCastOption ?? false,
+				updatedAt: new Date(),
+			},
+		});
+	}
+
+	public async getLatestCast(imdbId: string, userId: string): Promise<LatestCast | null> {
+		const castItem = await this.prisma.torrinCast.findFirst({
+			where: {
+				imdbId: imdbId,
+				userId: userId,
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			select: {
+				url: true,
+				link: true,
+			},
+		});
+		return castItem && castItem.url && castItem.link
+			? { url: castItem.url, link: castItem.link }
+			: null;
+	}
+
+	public async getCastURLs(
+		imdbId: string,
+		userId: string
+	): Promise<{ url: string; link: string | null; size: number }[]> {
+		const castItems = await this.prisma.torrinCast.findMany({
+			where: {
+				imdbId: imdbId,
+				userId: userId,
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			select: {
+				url: true,
+				size: true,
+				link: true,
+			},
+		});
+		return castItems
+			.filter(
+				(item): item is { url: string; link: string; size: bigint } => item.link !== null
+			)
+			.map((item) => ({
+				url: item.url,
+				link: item.link,
+				size: Number(item.size),
+			}));
+	}
+
+	public async getOtherCastURLs(
+		imdbId: string,
+		userId: string
+	): Promise<{ url: string; link: string; size: number }[]> {
+		const castItems = await this.prisma.torrinCast.findMany({
+			where: {
+				imdbId: imdbId,
+				link: {
+					not: null,
+				},
+				size: {
+					gt: 10,
+				},
+				userId: {
+					not: userId,
+				},
+			},
+			distinct: ['size'],
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			take: 2,
+			select: {
+				url: true,
+				link: true,
+				size: true,
+			},
+		});
+
+		return castItems
+			.filter((item): item is { url: string; link: string; size: bigint } => !!item.link)
+			.map((item) => ({
+				url: item.url,
+				link: item.link,
+				size: Number(item.size),
+			}));
+	}
+
+	public async getCastProfile(userId: string): Promise<{
+		baseUrl: string;
+		apiKey: string;
+		movieMaxSize: number;
+		episodeMaxSize: number;
+		otherStreamsLimit?: number;
+		hideCastOption?: boolean;
+	} | null> {
+		const profile = await this.prisma.torrinCastProfile.findUnique({
+			where: { userId },
+			select: {
+				baseUrl: true,
+				apiKey: true,
+				movieMaxSize: true,
+				episodeMaxSize: true,
+				otherStreamsLimit: true,
+				hideCastOption: true,
+			},
+		});
+		return profile;
+	}
+
+	public async saveCast(
+		imdbId: string,
+		userId: string,
+		hash: string,
+		url: string,
+		link: string,
+		fileSize: number
+	): Promise<void> {
+		await this.prisma.torrinCast.upsert({
+			where: {
+				imdbId_userId_hash: {
+					imdbId: imdbId,
+					userId: userId,
+					hash: hash,
+				},
+			},
+			update: {
+				imdbId: imdbId,
+				link: link,
+				url: url,
+				size: BigInt(fileSize),
+			},
+			create: {
+				imdbId: imdbId,
+				userId: userId,
+				hash: hash,
+				link: link,
+				url: url,
+				size: BigInt(fileSize),
+			},
+		});
+	}
+
+	public async fetchCastedMovies(userId: string): Promise<string[]> {
+		const movies = await this.prisma.torrinCast.findMany({
+			where: {
+				userId: userId,
+				imdbId: {
+					not: {
+						contains: ':',
+					},
+				},
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			distinct: ['imdbId'],
+			select: {
+				imdbId: true,
+			},
+		});
+
+		return movies.map((movie) => movie.imdbId);
+	}
+
+	public async fetchCastedShows(userId: string): Promise<string[]> {
+		const showsWithDuplicates = await this.prisma.torrinCast.findMany({
+			where: {
+				userId: userId,
+				imdbId: {
+					contains: ':',
+				},
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			select: {
+				imdbId: true,
+			},
+		});
+
+		const uniqueShows = showsWithDuplicates
+			.map((show) => show.imdbId.split(':')[0])
+			.filter((value, index, self) => self.indexOf(value) === index);
+
+		return uniqueShows;
+	}
+
+	public async fetchAllCastedLinks(userId: string): Promise<
+		{
+			imdbId: string;
+			url: string;
+			hash: string;
+			size: number;
+			updatedAt: Date;
+		}[]
+	> {
+		const castItems = await this.prisma.torrinCast.findMany({
+			where: {
+				userId: userId,
+			},
+			select: {
+				imdbId: true,
+				url: true,
+				hash: true,
+				size: true,
+				updatedAt: true,
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+		});
+
+		return castItems.map((item) => ({
+			...item,
+			size: Number(item.size),
+		}));
+	}
+
+	public async deleteCastedLink(imdbId: string, userId: string, hash: string): Promise<void> {
+		try {
+			await this.prisma.torrinCast.delete({
+				where: {
+					imdbId_userId_hash: {
+						imdbId,
+						userId,
+						hash,
+					},
+				},
+			});
+		} catch (error: any) {
+			throw new Error(`Failed to delete casted link: ${error.message}`);
+		}
+	}
+
+	public async getAllUserCasts(userId: string): Promise<
+		{
+			imdbId: string;
+			hash: string;
+			url: string;
+			link: string | null;
+			size: number;
+		}[]
+	> {
+		const casts = await this.prisma.torrinCast.findMany({
+			where: {
+				userId: userId,
+			},
+			select: {
+				imdbId: true,
+				hash: true,
+				url: true,
+				link: true,
+				size: true,
+			},
+		});
+		return casts.map((cast) => ({
+			imdbId: cast.imdbId,
+			hash: cast.hash,
+			url: cast.url,
+			link: cast.link,
+			size: Number(cast.size),
+		}));
+	}
+
+	public async getUserCastStreams(
+		imdbId: string,
+		userId: string,
+		limit: number = 5
+	): Promise<
+		{
+			url: string;
+			link: string;
+			size: number;
+			filename: string;
+			hash: string;
+		}[]
+	> {
+		const castItems = await this.prisma.torrinCast.findMany({
+			where: {
+				imdbId: imdbId,
+				userId: userId,
+				link: {
+					not: null,
+				},
+			},
+			orderBy: {
+				updatedAt: 'desc',
+			},
+			select: {
+				url: true,
+				link: true,
+				size: true,
+				hash: true,
+			},
+			take: limit,
+		});
+
+		return castItems
+			.filter(
+				(item): item is { url: string; link: string; size: bigint; hash: string } =>
+					item.link !== null
+			)
+			.map((item) => ({
+				url: item.url,
+				link: item.link,
+				size: Number(item.size),
+				filename: item.url.split('/').pop() || 'Unknown',
+				hash: item.hash,
+			}));
+	}
+
+	public async getOtherStreams(
+		imdbId: string,
+		userId: string,
+		limit: number = 5,
+		maxSize?: number
+	): Promise<
+		{
+			url: string;
+			link: string;
+			size: number;
+			filename: string;
+			hash: string;
+		}[]
+	> {
+		const hasMaxSize = typeof maxSize === 'number' && maxSize > 0;
+		const normalizedMaxSizeMb = hasMaxSize ? Math.round(maxSize * 1024) : undefined;
+		const maxSizeCastLimit =
+			normalizedMaxSizeMb !== undefined ? BigInt(normalizedMaxSizeMb) : undefined;
+
+		const otherCastItems = await this.prisma.torrinCast.findMany({
+			where: {
+				imdbId: imdbId,
+				link: {
+					not: null,
+				},
+				size: {
+					gt: 10,
+					...(maxSizeCastLimit !== undefined && { lte: maxSizeCastLimit }),
+				},
+				userId: {
+					not: userId,
+				},
+			},
+			distinct: ['size'],
+			orderBy: {
+				size: 'desc',
+			},
+			select: {
+				url: true,
+				link: true,
+				size: true,
+				hash: true,
+			},
+			take: limit,
+		});
+
+		return otherCastItems
+			.filter(
+				(item): item is { url: string; link: string; size: bigint; hash: string } =>
+					item.link !== null
+			)
+			.map((item) => ({
+				url: item.url,
+				link: item.link,
+				size: Number(item.size),
+				filename: item.url.split('/').pop() || 'Unknown',
+				hash: item.hash,
+			}));
+	}
+}

--- a/src/services/library/UnifiedLibraryFetcher.ts
+++ b/src/services/library/UnifiedLibraryFetcher.ts
@@ -6,12 +6,15 @@
 import { MagnetStatus, getMagnetStatus } from '@/services/allDebrid';
 import { getUserTorrentsList } from '@/services/realDebrid';
 import { getTorrentList } from '@/services/torbox';
+import { getTorrinTorrentsList } from '@/services/torrin';
 import { UserTorrent } from '@/torrent/userTorrent';
 import {
 	convertToAllDebridUserTorrent,
 	convertToTbUserTorrent,
+	convertToTorrinUserTorrent,
 	convertToUserTorrent,
 } from '@/utils/fetchTorrents';
+import { splitTorrinToken } from '@/utils/torrinToken';
 import { CacheManager, getGlobalCache } from '../cache/CacheManager';
 import { UnifiedRateLimiter, getGlobalRateLimiter } from '../rateLimit/UnifiedRateLimiter';
 
@@ -38,7 +41,7 @@ export class UnifiedLibraryFetcher {
 	 * Fetch library from any service with unified interface
 	 */
 	async fetchLibrary(
-		service: 'realdebrid' | 'alldebrid' | 'torbox',
+		service: 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin',
 		token: string,
 		options: FetchOptions = {}
 	): Promise<UserTorrent[]> {
@@ -75,7 +78,7 @@ export class UnifiedLibraryFetcher {
 	}
 
 	private async performFetch(
-		service: 'realdebrid' | 'alldebrid' | 'torbox',
+		service: 'realdebrid' | 'alldebrid' | 'torbox' | 'torrin',
 		token: string,
 		options: FetchOptions
 	): Promise<UserTorrent[]> {
@@ -86,6 +89,8 @@ export class UnifiedLibraryFetcher {
 				return this.fetchAllDebrid(token, options);
 			case 'torbox':
 				return this.fetchTorbox(token, options);
+			case 'torrin':
+				return this.fetchTorrin(token, options);
 			default:
 				throw new Error(`Unknown service: ${service}`);
 		}
@@ -374,9 +379,73 @@ export class UnifiedLibraryFetcher {
 		return allTorrents;
 	}
 
+	private async fetchTorrin(token: string, options: FetchOptions): Promise<UserTorrent[]> {
+		const { baseUrl, apiKey } = splitTorrinToken(token);
+		if (!baseUrl || !apiKey) {
+			throw new Error('Torrin requires an instance URL and API key');
+		}
+		const cacheKey = `tr:library:${token}`;
+
+		if (!options.forceRefresh) {
+			const cached = await this.cache.get<UserTorrent[]>(cacheKey);
+			if (cached) {
+				return cached;
+			}
+		}
+
+		const firstPageResult = await this.rateLimiter.execute('torrin', 'tr-first-page', () =>
+			getTorrinTorrentsList(baseUrl, apiKey, 1, 1)
+		);
+
+		if (!firstPageResult.data.length) {
+			await this.cache.set(cacheKey, [], undefined, 5 * 60 * 1000);
+			return [];
+		}
+
+		const totalCount = Math.min(firstPageResult.totalCount || 0, options.maxItems || Infinity);
+		const pageSize = 1500;
+		const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+		const concurrency = options.concurrency || 4;
+
+		options.onProgress?.(0, totalCount);
+
+		const pages: number[] = [];
+		for (let page = 1; page <= totalPages; page++) {
+			pages.push(page);
+		}
+
+		const allTorrents: UserTorrent[] = [];
+		for (let i = 0; i < pages.length; i += concurrency) {
+			if (options.signal?.aborted) {
+				throw new Error('Fetch aborted');
+			}
+			const batch = pages.slice(i, i + concurrency);
+			const batchResults = await Promise.all(
+				batch.map((page) =>
+					this.rateLimiter.execute('torrin', `tr-page-${page}`, () =>
+						getTorrinTorrentsList(baseUrl, apiKey, pageSize, page)
+					)
+				)
+			);
+			for (const result of batchResults) {
+				const torrents = await this.processTorrinTorrents(result.data);
+				allTorrents.push(...torrents);
+				options.onBatchComplete?.(torrents);
+				options.onProgress?.(allTorrents.length, totalCount);
+			}
+		}
+
+		await this.cache.set(cacheKey, allTorrents, undefined, 5 * 60 * 1000);
+		return allTorrents;
+	}
+
 	// Conversion helpers (these would import from existing utils)
 	private async processRealDebridTorrents(data: any[]): Promise<UserTorrent[]> {
 		return data.map((t) => convertToUserTorrent(t));
+	}
+
+	private async processTorrinTorrents(data: any[]): Promise<UserTorrent[]> {
+		return data.map((t) => convertToTorrinUserTorrent(t));
 	}
 
 	private async processAllDebridMagnets(magnets: MagnetStatus[]): Promise<UserTorrent[]> {

--- a/src/services/library/UnifiedLibraryFetcher.ts
+++ b/src/services/library/UnifiedLibraryFetcher.ts
@@ -402,8 +402,38 @@ export class UnifiedLibraryFetcher {
 			return [];
 		}
 
-		const totalCount = Math.min(firstPageResult.totalCount || 0, options.maxItems || Infinity);
 		const pageSize = 1500;
+
+		if (!firstPageResult.totalCount) {
+			const allTorrents: UserTorrent[] = [];
+			let page = 1;
+			while (true) {
+				if (options.signal?.aborted) {
+					throw new Error('Fetch aborted');
+				}
+				const result = await this.rateLimiter.execute('torrin', `tr-page-${page}`, () =>
+					getTorrinTorrentsList(baseUrl, apiKey, pageSize, page)
+				);
+				if (!result.data.length) {
+					break;
+				}
+				const torrents = await this.processTorrinTorrents(result.data);
+				allTorrents.push(...torrents);
+				options.onBatchComplete?.(torrents);
+				options.onProgress?.(allTorrents.length, allTorrents.length);
+				if (result.data.length < pageSize) {
+					break;
+				}
+				if (options.maxItems && allTorrents.length >= options.maxItems) {
+					break;
+				}
+				page++;
+			}
+			await this.cache.set(cacheKey, allTorrents, undefined, 5 * 60 * 1000);
+			return allTorrents;
+		}
+
+		const totalCount = Math.min(firstPageResult.totalCount, options.maxItems || Infinity);
 		const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 		const concurrency = options.concurrency || 4;
 

--- a/src/services/mediasearch.ts
+++ b/src/services/mediasearch.ts
@@ -18,6 +18,7 @@ export type SearchResult = {
 	rdAvailable: boolean; // Real Debrid
 	adAvailable: boolean; // AllDebrid
 	tbAvailable: boolean; // Torbox
+	torrinAvailable?: boolean; // Torrin
 	files: FileData[];
 	noVideos: boolean;
 	// for cached results in RD
@@ -54,6 +55,7 @@ export interface EnrichedHashlistTorrent extends HashlistTorrent {
 	rdAvailable: boolean;
 	adAvailable: boolean;
 	tbAvailable: boolean; // TorBox
+	torrinAvailable?: boolean; // Torrin
 	files: FileData[];
 }
 

--- a/src/services/rateLimit/UnifiedRateLimiter.ts
+++ b/src/services/rateLimit/UnifiedRateLimiter.ts
@@ -61,6 +61,15 @@ export class UnifiedRateLimiter {
 			burstSize: 10,
 		});
 
+		this.configs.set('torrin', {
+			maxRequestsPerMinute: 250,
+			maxConcurrent: 4,
+			retryAttempts: 3,
+			backoffMultiplier: 2,
+			jitterRange: 0.2,
+			burstSize: 10,
+		});
+
 		// Initialize structures for each service
 		for (const service of this.configs.keys()) {
 			this.queues.set(service, []);

--- a/src/services/repository.ts
+++ b/src/services/repository.ts
@@ -16,6 +16,7 @@ import {
 	StreamHealthService,
 	TorBoxCastService,
 	TorrentSnapshotService,
+	TorrinCastService,
 	ZurgKeysService,
 } from './database';
 import { HashSearchParams } from './database/hashSearch';
@@ -31,6 +32,7 @@ export type RepositoryDependencies = Partial<{
 	animeService: AnimeService;
 	castService: CastService;
 	torboxCastService: TorBoxCastService;
+	torrinCastService: TorrinCastService;
 	allDebridCastService: AllDebridCastService;
 	reportService: ReportService;
 	torrentSnapshotService: TorrentSnapshotService;
@@ -51,6 +53,7 @@ export class Repository {
 	private animeService: AnimeService;
 	private castService: CastService;
 	private torboxCastService: TorBoxCastService;
+	private torrinCastService: TorrinCastService;
 	private allDebridCastService: AllDebridCastService;
 	private reportService: ReportService;
 	private torrentSnapshotService: TorrentSnapshotService;
@@ -70,6 +73,7 @@ export class Repository {
 		animeService,
 		castService,
 		torboxCastService,
+		torrinCastService,
 		allDebridCastService,
 		reportService,
 		torrentSnapshotService,
@@ -88,6 +92,7 @@ export class Repository {
 		this.animeService = animeService ?? new AnimeService();
 		this.castService = castService ?? new CastService();
 		this.torboxCastService = torboxCastService ?? new TorBoxCastService();
+		this.torrinCastService = torrinCastService ?? new TorrinCastService();
 		this.allDebridCastService = allDebridCastService ?? new AllDebridCastService();
 		this.reportService = reportService ?? new ReportService();
 		this.torrentSnapshotService = torrentSnapshotService ?? new TorrentSnapshotService();
@@ -111,6 +116,7 @@ export class Repository {
 			this.animeService.disconnect(),
 			this.castService.disconnect(),
 			this.torboxCastService.disconnect(),
+			this.torrinCastService.disconnect(),
 			this.allDebridCastService.disconnect(),
 			this.reportService.disconnect(),
 			this.torrentSnapshotService.disconnect(),
@@ -453,6 +459,82 @@ export class Repository {
 
 	public getTorBoxOtherStreams(imdbId: string, userId: string, limit?: number, maxSize?: number) {
 		return this.torboxCastService.getOtherStreams(imdbId, userId, limit, maxSize);
+	}
+
+	// Torrin Cast Service Methods
+	public saveTorrinCastProfile(
+		userId: string,
+		baseUrl: string,
+		apiKey: string,
+		movieMaxSize?: number,
+		episodeMaxSize?: number,
+		otherStreamsLimit?: number,
+		hideCastOption?: boolean
+	) {
+		return this.torrinCastService.saveCastProfile(
+			userId,
+			baseUrl,
+			apiKey,
+			movieMaxSize,
+			episodeMaxSize,
+			otherStreamsLimit,
+			hideCastOption
+		);
+	}
+
+	public getTorrinLatestCast(imdbId: string, userId: string) {
+		return this.torrinCastService.getLatestCast(imdbId, userId);
+	}
+
+	public getTorrinCastURLs(imdbId: string, userId: string) {
+		return this.torrinCastService.getCastURLs(imdbId, userId);
+	}
+
+	public getTorrinOtherCastURLs(imdbId: string, userId: string) {
+		return this.torrinCastService.getOtherCastURLs(imdbId, userId);
+	}
+
+	public getTorrinCastProfile(userId: string) {
+		return this.torrinCastService.getCastProfile(userId);
+	}
+
+	public saveTorrinCast(
+		imdbId: string,
+		userId: string,
+		hash: string,
+		url: string,
+		link: string,
+		fileSize: number
+	) {
+		return this.torrinCastService.saveCast(imdbId, userId, hash, url, link, fileSize);
+	}
+
+	public fetchTorrinCastedMovies(userId: string) {
+		return this.torrinCastService.fetchCastedMovies(userId);
+	}
+
+	public fetchTorrinCastedShows(userId: string) {
+		return this.torrinCastService.fetchCastedShows(userId);
+	}
+
+	public fetchAllTorrinCastedLinks(userId: string) {
+		return this.torrinCastService.fetchAllCastedLinks(userId);
+	}
+
+	public deleteTorrinCastedLink(imdbId: string, userId: string, hash: string) {
+		return this.torrinCastService.deleteCastedLink(imdbId, userId, hash);
+	}
+
+	public getAllTorrinUserCasts(userId: string) {
+		return this.torrinCastService.getAllUserCasts(userId);
+	}
+
+	public getTorrinUserCastStreams(imdbId: string, userId: string, limit?: number) {
+		return this.torrinCastService.getUserCastStreams(imdbId, userId, limit);
+	}
+
+	public getTorrinOtherStreams(imdbId: string, userId: string, limit?: number, maxSize?: number) {
+		return this.torrinCastService.getOtherStreams(imdbId, userId, limit, maxSize);
 	}
 
 	// AllDebrid Cast Service Methods

--- a/src/services/repository.ts
+++ b/src/services/repository.ts
@@ -504,9 +504,10 @@ export class Repository {
 		hash: string,
 		url: string,
 		link: string,
-		fileSize: number
+		fileSize: number,
+		baseUrl: string
 	) {
-		return this.torrinCastService.saveCast(imdbId, userId, hash, url, link, fileSize);
+		return this.torrinCastService.saveCast(imdbId, userId, hash, url, link, fileSize, baseUrl);
 	}
 
 	public fetchTorrinCastedMovies(userId: string) {
@@ -533,8 +534,14 @@ export class Repository {
 		return this.torrinCastService.getUserCastStreams(imdbId, userId, limit);
 	}
 
-	public getTorrinOtherStreams(imdbId: string, userId: string, limit?: number, maxSize?: number) {
-		return this.torrinCastService.getOtherStreams(imdbId, userId, limit, maxSize);
+	public getTorrinOtherStreams(
+		imdbId: string,
+		userId: string,
+		baseUrl: string,
+		limit?: number,
+		maxSize?: number
+	) {
+		return this.torrinCastService.getOtherStreams(imdbId, userId, baseUrl, limit, maxSize);
 	}
 
 	// AllDebrid Cast Service Methods

--- a/src/services/torrin.test.ts
+++ b/src/services/torrin.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { addTorrinMagnet, getTorrinUser, torrinInstantCheck, unrestrictTorrinLink } from './torrin';
+
+const mocks = vi.hoisted(() => ({
+	getMock: vi.fn(),
+	postMock: vi.fn(),
+	deleteMock: vi.fn(),
+}));
+
+vi.mock('axios', () => ({
+	default: {
+		get: mocks.getMock,
+		post: mocks.postMock,
+		delete: mocks.deleteMock,
+	},
+}));
+
+const BASE = 'https://torrin.test';
+const KEY = 'testkey';
+
+describe('torrin service', () => {
+	beforeEach(() => {
+		mocks.getMock.mockReset();
+		mocks.postMock.mockReset();
+		mocks.deleteMock.mockReset();
+	});
+
+	it('getTorrinUser hits /rest/1.0/user with Bearer auth', async () => {
+		mocks.getMock.mockResolvedValue({ data: { id: 1, username: 'u' } });
+		const user = await getTorrinUser(BASE, KEY);
+		expect(user.username).toBe('u');
+		const [url, cfg] = mocks.getMock.mock.calls[0];
+		expect(url).toBe(`${BASE}/rest/1.0/user`);
+		expect(cfg.headers.Authorization).toBe(`Bearer ${KEY}`);
+	});
+
+	it('trims trailing slashes from the base url', async () => {
+		mocks.getMock.mockResolvedValue({ data: {} });
+		await getTorrinUser('https://torrin.test///', KEY);
+		expect(mocks.getMock.mock.calls[0][0]).toBe(`${BASE}/rest/1.0/user`);
+	});
+
+	it('addTorrinMagnet posts a magnet and returns the id', async () => {
+		mocks.postMock.mockResolvedValue({ status: 201, data: { id: 'abc' } });
+		const id = await addTorrinMagnet(BASE, KEY, '0123456789abcdef0123456789abcdef01234567');
+		expect(id).toBe('abc');
+		expect(mocks.postMock.mock.calls[0][0]).toBe(`${BASE}/rest/1.0/torrents/addMagnet`);
+	});
+
+	it('torrinInstantCheck short-circuits with no hashes', async () => {
+		const res = await torrinInstantCheck(BASE, KEY, []);
+		expect(res).toEqual({});
+		expect(mocks.getMock).not.toHaveBeenCalled();
+	});
+
+	it('unrestrictTorrinLink posts to /unrestrict/link', async () => {
+		mocks.postMock.mockResolvedValue({ data: { download: 'https://dl' } });
+		const r = await unrestrictTorrinLink(BASE, KEY, 'https://host/f');
+		expect((r as { download: string }).download).toBe('https://dl');
+		expect(mocks.postMock.mock.calls[0][0]).toBe(`${BASE}/rest/1.0/unrestrict/link`);
+	});
+});

--- a/src/services/torrin.ts
+++ b/src/services/torrin.ts
@@ -1,0 +1,133 @@
+import axios from 'axios';
+import qs from 'qs';
+import {
+	TorrentInfoResponse,
+	UnrestrictResponse,
+	UserResponse,
+	UserTorrentResponse,
+	UserTorrentsResult,
+} from './types';
+
+// Torrin is a self-hostable, open-source debrid service (AGPL) that exposes a RealDebrid-compatible
+// API at {baseUrl}/rest/1.0/*, authed with the instance's API key as a Bearer token. No OAuth: the
+// key is issued directly by the torrin instance, so callers pass (baseUrl, apiKey) rather than an
+// OAuth access token. Response shapes match RealDebrid's, so the shared types are reused.
+
+const REQUEST_TIMEOUT = 10000;
+const TORRENT_REQUEST_TIMEOUT = 60000;
+
+function apiBase(baseUrl: string): string {
+	return baseUrl.replace(/\/+$/, '') + '/rest/1.0';
+}
+
+function authHeaders(apiKey: string): Record<string, string> {
+	return { Authorization: `Bearer ${apiKey}` };
+}
+
+function formHeaders(apiKey: string): Record<string, string> {
+	return { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeaders(apiKey) };
+}
+
+export const getTorrinUser = async (baseUrl: string, apiKey: string): Promise<UserResponse> => {
+	const { data } = await axios.get<UserResponse>(`${apiBase(baseUrl)}/user`, {
+		headers: authHeaders(apiKey),
+		timeout: REQUEST_TIMEOUT,
+	});
+	return data;
+};
+
+export const getTorrinTorrentsList = async (
+	baseUrl: string,
+	apiKey: string,
+	limit: number = 1,
+	page: number = 1
+): Promise<UserTorrentsResult> => {
+	const res = await axios.get<UserTorrentResponse[]>(
+		`${apiBase(baseUrl)}/torrents?page=${page}&limit=${limit}&_fresh=${Date.now()}`,
+		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT }
+	);
+	const total = res.headers['x-total-count'];
+	const parsed = total ? parseInt(total, 10) : NaN;
+	return {
+		data: Array.isArray(res.data) ? res.data : [],
+		totalCount: isNaN(parsed) ? null : parsed,
+	};
+};
+
+export const getTorrinTorrentInfo = async (
+	baseUrl: string,
+	apiKey: string,
+	id: string
+): Promise<TorrentInfoResponse> => {
+	const { data } = await axios.get<TorrentInfoResponse>(
+		`${apiBase(baseUrl)}/torrents/info/${id}`,
+		{
+			headers: authHeaders(apiKey),
+			timeout: REQUEST_TIMEOUT,
+		}
+	);
+	return data;
+};
+
+export const addTorrinMagnet = async (
+	baseUrl: string,
+	apiKey: string,
+	hash: string
+): Promise<string> => {
+	const { data, status } = await axios.post(
+		`${apiBase(baseUrl)}/torrents/addMagnet`,
+		qs.stringify({ magnet: `magnet:?xt=urn:btih:${hash}` }),
+		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT }
+	);
+	if (status !== 201) throw new Error(`torrin addMagnet failed, status ${status}`);
+	return data.id;
+};
+
+export const selectTorrinFiles = async (
+	baseUrl: string,
+	apiKey: string,
+	id: string,
+	files: string = 'all'
+): Promise<void> => {
+	await axios.post(`${apiBase(baseUrl)}/torrents/selectFiles/${id}`, qs.stringify({ files }), {
+		headers: formHeaders(apiKey),
+		timeout: REQUEST_TIMEOUT,
+	});
+};
+
+export const deleteTorrinTorrent = async (
+	baseUrl: string,
+	apiKey: string,
+	id: string
+): Promise<void> => {
+	await axios.delete(`${apiBase(baseUrl)}/torrents/delete/${id}`, {
+		headers: authHeaders(apiKey),
+		timeout: REQUEST_TIMEOUT,
+	});
+};
+
+export const unrestrictTorrinLink = async (
+	baseUrl: string,
+	apiKey: string,
+	link: string
+): Promise<UnrestrictResponse> => {
+	const { data } = await axios.post<UnrestrictResponse>(
+		`${apiBase(baseUrl)}/unrestrict/link`,
+		qs.stringify({ link }),
+		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT }
+	);
+	return data;
+};
+
+export const torrinInstantCheck = async (
+	baseUrl: string,
+	apiKey: string,
+	hashes: string[]
+): Promise<Record<string, unknown>> => {
+	if (hashes.length === 0) return {};
+	const { data } = await axios.get(
+		`${apiBase(baseUrl)}/torrents/instantAvailability/${hashes.join('/')}`,
+		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT }
+	);
+	return data ?? {};
+};

--- a/src/services/torrin.ts
+++ b/src/services/torrin.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import dns from 'dns';
+import net from 'net';
 import qs from 'qs';
 import {
 	TorrentInfoResponse,
@@ -32,8 +33,9 @@ function isBlockedAddress(ip: string): boolean {
 		return false;
 	}
 	const v6 = addr.toLowerCase();
-	if (v6 === '::1') return true;
-	if (v6.startsWith('fe80')) return true;
+	if (v6 === '::' || v6 === '::1') return true;
+	if (v6.startsWith('fe80')) return true; // link-local
+	if (v6.startsWith('fc') || v6.startsWith('fd')) return true; // unique-local fc00::/7
 	return false;
 }
 
@@ -60,7 +62,20 @@ const guard: Pick<AxiosRequestConfig, 'lookup' | 'maxRedirects'> = {
 };
 
 function apiBase(baseUrl: string): string {
-	return baseUrl.replace(/\/+$/, '') + '/rest/1.0';
+	const cleaned = baseUrl.replace(/\/+$/, '');
+	let hostname: string;
+	try {
+		hostname = new URL(cleaned).hostname;
+	} catch {
+		throw new Error('invalid torrin base URL');
+	}
+	// IP-literal hosts (e.g. http://127.0.0.1, http://[::1]) never hit the DNS
+	// lookup guard, so reject blocked literals directly here.
+	const bare = hostname.replace(/^\[|\]$/g, '');
+	if (net.isIP(bare) && isBlockedAddress(bare)) {
+		throw new Error(`blocked host: ${bare}`);
+	}
+	return cleaned + '/rest/1.0';
 }
 
 function authHeaders(apiKey: string): Record<string, string> {
@@ -103,12 +118,23 @@ export const findTorrinTorrentByHash = async (
 	apiKey: string,
 	hash: string
 ): Promise<UserTorrentResponse | null> => {
-	try {
-		const res = await getTorrinTorrentsList(baseUrl, apiKey, 1000, 1);
-		return res.data.find((t) => t.hash?.toLowerCase() === hash.toLowerCase()) ?? null;
-	} catch {
-		return null;
+	const target = hash.toLowerCase();
+	const pageSize = 1000;
+	let page = 1;
+	let seen = 0;
+	let total = Infinity;
+	// Page through the whole library. Errors propagate on purpose: a failed lookup
+	// must never be mistaken for "not found", which would add a duplicate torrent.
+	while (seen < total) {
+		const res = await getTorrinTorrentsList(baseUrl, apiKey, pageSize, page);
+		const match = res.data.find((t) => t.hash?.toLowerCase() === target);
+		if (match) return match;
+		if (res.totalCount !== null) total = res.totalCount;
+		seen += res.data.length;
+		if (res.data.length === 0) break;
+		page++;
 	}
+	return null;
 };
 
 export const getTorrinTorrentInfo = async (

--- a/src/services/torrin.ts
+++ b/src/services/torrin.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
+import dns from 'dns';
 import qs from 'qs';
 import {
 	TorrentInfoResponse,
@@ -16,6 +17,48 @@ import {
 const REQUEST_TIMEOUT = 10000;
 const TORRENT_REQUEST_TIMEOUT = 60000;
 
+function isBlockedAddress(ip: string): boolean {
+	let addr = ip;
+	if (addr.startsWith('::ffff:')) addr = addr.slice(7);
+	const parts = addr.split('.');
+	if (parts.length === 4 && parts.every((p) => /^\d+$/.test(p))) {
+		const [a, b] = parts.map(Number);
+		if (a === 127) return true;
+		if (a === 10) return true;
+		if (a === 172 && b >= 16 && b <= 31) return true;
+		if (a === 192 && b === 168) return true;
+		if (a === 169 && b === 254) return true;
+		if (a === 100 && b >= 64 && b <= 127) return true;
+		return false;
+	}
+	const v6 = addr.toLowerCase();
+	if (v6 === '::1') return true;
+	if (v6.startsWith('fe80')) return true;
+	return false;
+}
+
+function pinnedLookup(
+	hostname: string,
+	options: dns.LookupOptions,
+	callback: (err: NodeJS.ErrnoException | null, address: any, family?: number) => void
+): void {
+	dns.lookup(hostname, { all: true }, (err, addresses) => {
+		if (err) return callback(err, '', 0);
+		if (addresses.length === 0 || addresses.some((a) => isBlockedAddress(a.address))) {
+			return callback(new Error(`blocked host: ${hostname}`), '', 0);
+		}
+		if (options && options.all) {
+			return callback(null, addresses);
+		}
+		callback(null, addresses[0].address, addresses[0].family);
+	});
+}
+
+const guard: Pick<AxiosRequestConfig, 'lookup' | 'maxRedirects'> = {
+	lookup: pinnedLookup as AxiosRequestConfig['lookup'],
+	maxRedirects: 0,
+};
+
 function apiBase(baseUrl: string): string {
 	return baseUrl.replace(/\/+$/, '') + '/rest/1.0';
 }
@@ -32,6 +75,7 @@ export const getTorrinUser = async (baseUrl: string, apiKey: string): Promise<Us
 	const { data } = await axios.get<UserResponse>(`${apiBase(baseUrl)}/user`, {
 		headers: authHeaders(apiKey),
 		timeout: REQUEST_TIMEOUT,
+		...guard,
 	});
 	return data;
 };
@@ -44,7 +88,7 @@ export const getTorrinTorrentsList = async (
 ): Promise<UserTorrentsResult> => {
 	const res = await axios.get<UserTorrentResponse[]>(
 		`${apiBase(baseUrl)}/torrents?page=${page}&limit=${limit}&_fresh=${Date.now()}`,
-		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT }
+		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT, ...guard }
 	);
 	const total = res.headers['x-total-count'];
 	const parsed = total ? parseInt(total, 10) : NaN;
@@ -52,6 +96,19 @@ export const getTorrinTorrentsList = async (
 		data: Array.isArray(res.data) ? res.data : [],
 		totalCount: isNaN(parsed) ? null : parsed,
 	};
+};
+
+export const findTorrinTorrentByHash = async (
+	baseUrl: string,
+	apiKey: string,
+	hash: string
+): Promise<UserTorrentResponse | null> => {
+	try {
+		const res = await getTorrinTorrentsList(baseUrl, apiKey, 1000, 1);
+		return res.data.find((t) => t.hash?.toLowerCase() === hash.toLowerCase()) ?? null;
+	} catch {
+		return null;
+	}
 };
 
 export const getTorrinTorrentInfo = async (
@@ -64,6 +121,7 @@ export const getTorrinTorrentInfo = async (
 		{
 			headers: authHeaders(apiKey),
 			timeout: REQUEST_TIMEOUT,
+			...guard,
 		}
 	);
 	return data;
@@ -77,7 +135,7 @@ export const addTorrinMagnet = async (
 	const { data, status } = await axios.post(
 		`${apiBase(baseUrl)}/torrents/addMagnet`,
 		qs.stringify({ magnet: `magnet:?xt=urn:btih:${hash}` }),
-		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT }
+		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT, ...guard }
 	);
 	if (status !== 201) throw new Error(`torrin addMagnet failed, status ${status}`);
 	return data.id;
@@ -92,6 +150,7 @@ export const selectTorrinFiles = async (
 	await axios.post(`${apiBase(baseUrl)}/torrents/selectFiles/${id}`, qs.stringify({ files }), {
 		headers: formHeaders(apiKey),
 		timeout: REQUEST_TIMEOUT,
+		...guard,
 	});
 };
 
@@ -103,6 +162,7 @@ export const deleteTorrinTorrent = async (
 	await axios.delete(`${apiBase(baseUrl)}/torrents/delete/${id}`, {
 		headers: authHeaders(apiKey),
 		timeout: REQUEST_TIMEOUT,
+		...guard,
 	});
 };
 
@@ -114,7 +174,7 @@ export const unrestrictTorrinLink = async (
 	const { data } = await axios.post<UnrestrictResponse>(
 		`${apiBase(baseUrl)}/unrestrict/link`,
 		qs.stringify({ link }),
-		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT }
+		{ headers: formHeaders(apiKey), timeout: REQUEST_TIMEOUT, ...guard }
 	);
 	return data;
 };
@@ -127,7 +187,7 @@ export const torrinInstantCheck = async (
 	if (hashes.length === 0) return {};
 	const { data } = await axios.get(
 		`${apiBase(baseUrl)}/torrents/instantAvailability/${hashes.join('/')}`,
-		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT }
+		{ headers: authHeaders(apiKey), timeout: TORRENT_REQUEST_TIMEOUT, ...guard }
 	);
 	return data ?? {};
 };

--- a/src/test/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json.test.ts
+++ b/src/test/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json.test.ts
@@ -1,0 +1,68 @@
+import handler from '@/pages/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json';
+import { repository } from '@/services/repository';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/repository');
+
+const mockRepository = vi.mocked(repository);
+
+describe('/api/stremio-tr/[userid]/catalog/movie/tr-casted-movies.json', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+		mockRepository.fetchTorrinCastedMovies = vi.fn();
+	});
+
+	it('sets CORS header', async () => {
+		mockRepository.fetchTorrinCastedMovies = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 200 for OPTIONS request', async () => {
+		const req = createMockRequest({ method: 'OPTIONS', query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('returns 400 when userid is missing', async () => {
+		const req = createMockRequest({ query: {} });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns metas with poster URLs', async () => {
+		mockRepository.fetchTorrinCastedMovies = vi
+			.fn()
+			.mockResolvedValue(['tt1234567', 'tt7654321']);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data.metas).toEqual([
+			{
+				id: 'tt1234567',
+				type: 'movie',
+				poster: 'https://images.metahub.space/poster/small/tt1234567/img',
+			},
+			{
+				id: 'tt7654321',
+				type: 'movie',
+				poster: 'https://images.metahub.space/poster/small/tt7654321/img',
+			},
+		]);
+		expect(data.cacheMaxAge).toBe(0);
+	});
+
+	it('returns 500 on error', async () => {
+		mockRepository.fetchTorrinCastedMovies = vi.fn().mockRejectedValue(new Error('DB error'));
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json.test.ts
+++ b/src/test/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json.test.ts
@@ -1,0 +1,55 @@
+import handler from '@/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { getTorrinDMMLibrary } from '@/utils/torrinCastCatalogHelper';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/torrinCastCatalogHelper');
+
+const mockGetTorrinDMMLibrary = vi.mocked(getTorrinDMMLibrary);
+
+describe('/api/stremio-tr/[userid]/catalog/other/tr-casted-other.json', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+	});
+
+	it('sets CORS header', async () => {
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: { metas: [] }, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 400 when userid is missing', async () => {
+		const req = createMockRequest({ query: {} });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 200 for OPTIONS request', async () => {
+		const req = createMockRequest({ method: 'OPTIONS', query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('returns library data on success', async () => {
+		const mockData = { metas: [{ id: 'dmm-tr:123', type: 'other' }], cacheMaxAge: 0 };
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: mockData, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(mockGetTorrinDMMLibrary).toHaveBeenCalledWith('user1', 1);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data).toEqual(mockData);
+	});
+
+	it('returns error status from helper', async () => {
+		mockGetTorrinDMMLibrary.mockResolvedValue({ error: 'No profile', status: 401 } as any);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(401);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip].test.ts
+++ b/src/test/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip].test.ts
@@ -1,0 +1,93 @@
+import handler from '@/pages/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip]';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { PAGE_SIZE, getTorrinDMMLibrary } from '@/utils/torrinCastCatalogHelper';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/torrinCastCatalogHelper', async (importOriginal) => {
+	const actual = (await importOriginal()) as any;
+	return {
+		...actual,
+		PAGE_SIZE: 12,
+		getTorrinDMMLibrary: vi.fn(),
+	};
+});
+
+const mockGetTorrinDMMLibrary = vi.mocked(getTorrinDMMLibrary);
+
+describe('/api/stremio-tr/[userid]/catalog/other/tr-casted-other/[skip]', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+	});
+
+	it('sets CORS header', async () => {
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: { metas: [] }, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', skip: '0' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 400 when userid is missing', async () => {
+		const req = createMockRequest({ query: { skip: '0' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 400 when skip is missing', async () => {
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 200 for OPTIONS request', async () => {
+		const req = createMockRequest({
+			method: 'OPTIONS',
+			query: { userid: 'user1', skip: '0' },
+		});
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('returns 400 for invalid skip value', async () => {
+		const req = createMockRequest({ query: { userid: 'user1', skip: 'invalid' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('converts skip to page number', async () => {
+		const mockData = { metas: [], cacheMaxAge: 0 };
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: mockData, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', skip: '24' } });
+		await handler(req, res);
+		const expectedPage = Math.floor(24 / PAGE_SIZE) + 1;
+		expect(mockGetTorrinDMMLibrary).toHaveBeenCalledWith('user1', expectedPage);
+	});
+
+	it('handles skip with .json suffix', async () => {
+		const mockData = { metas: [], cacheMaxAge: 0 };
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: mockData, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', skip: '12.json' } });
+		await handler(req, res);
+		expect(mockGetTorrinDMMLibrary).toHaveBeenCalledWith('user1', 2);
+	});
+
+	it('returns library data on success', async () => {
+		const mockData = { metas: [{ id: 'dmm-tr:456', type: 'other' }], cacheMaxAge: 0 };
+		mockGetTorrinDMMLibrary.mockResolvedValue({ data: mockData, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', skip: '0' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data).toEqual(mockData);
+	});
+
+	it('returns error status from helper', async () => {
+		mockGetTorrinDMMLibrary.mockResolvedValue({ error: 'No profile', status: 401 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', skip: '0' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(401);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json.test.ts
+++ b/src/test/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json.test.ts
@@ -1,0 +1,68 @@
+import handler from '@/pages/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json';
+import { repository } from '@/services/repository';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/repository');
+
+const mockRepository = vi.mocked(repository);
+
+describe('/api/stremio-tr/[userid]/catalog/series/tr-casted-shows.json', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+		mockRepository.fetchTorrinCastedShows = vi.fn();
+	});
+
+	it('sets CORS header', async () => {
+		mockRepository.fetchTorrinCastedShows = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 200 for OPTIONS request', async () => {
+		const req = createMockRequest({ method: 'OPTIONS', query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('returns 400 when userid is missing', async () => {
+		const req = createMockRequest({ query: {} });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns metas with poster URLs', async () => {
+		mockRepository.fetchTorrinCastedShows = vi
+			.fn()
+			.mockResolvedValue(['tt1111111', 'tt2222222']);
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data.metas).toEqual([
+			{
+				id: 'tt1111111',
+				type: 'series',
+				poster: 'https://images.metahub.space/poster/small/tt1111111/img',
+			},
+			{
+				id: 'tt2222222',
+				type: 'series',
+				poster: 'https://images.metahub.space/poster/small/tt2222222/img',
+			},
+		]);
+		expect(data.cacheMaxAge).toBe(0);
+	});
+
+	it('returns 500 on error', async () => {
+		mockRepository.fetchTorrinCastedShows = vi.fn().mockRejectedValue(new Error('DB error'));
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/manifest.json.test.ts
+++ b/src/test/api/stremio-tr/[userid]/manifest.json.test.ts
@@ -1,0 +1,60 @@
+import handler from '@/pages/api/stremio-tr/[userid]/manifest.json';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('/api/stremio-tr/[userid]/manifest.json', () => {
+	let req: ReturnType<typeof createMockRequest>;
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		req = createMockRequest({ query: { userid: 'test-user' } });
+		res = createMockResponse();
+	});
+
+	it('returns 200', async () => {
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it('sets CORS header', async () => {
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns correct manifest id and name', async () => {
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.id).toBe('com.debridmediamanager.cast.torrin');
+		expect(data.name).toBe('DMM Cast for Torrin');
+	});
+
+	it('includes catalogs', async () => {
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.catalogs).toHaveLength(3);
+		expect(data.catalogs[0].id).toBe('tr-casted-movies');
+		expect(data.catalogs[1].id).toBe('tr-casted-shows');
+		expect(data.catalogs[2].id).toBe('tr-casted-other');
+	});
+
+	it('includes resources', async () => {
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.resources).toHaveLength(2);
+		expect(data.resources[0].name).toBe('stream');
+		expect(data.resources[1].name).toBe('meta');
+		expect(data.resources[1].idPrefixes).toEqual(['dmm-tr']);
+	});
+
+	it('includes types', async () => {
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.types).toEqual(['movie', 'series', 'other']);
+	});
+
+	it('includes behaviorHints', async () => {
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.behaviorHints).toEqual({ adult: false, p2p: false });
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/meta/other/[id].test.ts
+++ b/src/test/api/stremio-tr/[userid]/meta/other/[id].test.ts
@@ -1,0 +1,81 @@
+import handler from '@/pages/api/stremio-tr/[userid]/meta/other/[id]';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { getTorrinDMMTorrent } from '@/utils/torrinCastCatalogHelper';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/torrinCastCatalogHelper');
+
+const mockGetTorrinDMMTorrent = vi.mocked(getTorrinDMMTorrent);
+
+describe('/api/stremio-tr/[userid]/meta/other/[id]', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+	});
+
+	it('sets CORS header', async () => {
+		const req = createMockRequest({ query: { userid: 'user1', id: 'dmm-tr:123' } });
+		mockGetTorrinDMMTorrent.mockResolvedValue({ data: { meta: null }, status: 200 } as any);
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 400 when userid or id is missing', async () => {
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 200 for OPTIONS request', async () => {
+		const req = createMockRequest({
+			method: 'OPTIONS',
+			query: { userid: 'user1', id: 'dmm-tr:123' },
+		});
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('returns null meta when id does not start with dmm-tr:', async () => {
+		const req = createMockRequest({ query: { userid: 'user1', id: 'tt1234567' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data.meta).toBeNull();
+		expect(mockGetTorrinDMMTorrent).not.toHaveBeenCalled();
+	});
+
+	it('strips .json suffix from id', async () => {
+		const req = createMockRequest({ query: { userid: 'user1', id: 'dmm-tr:123.json' } });
+		mockGetTorrinDMMTorrent.mockResolvedValue({ data: { meta: {} }, status: 200 } as any);
+		await handler(req, res);
+		expect(mockGetTorrinDMMTorrent).toHaveBeenCalledWith('user1', '123');
+	});
+
+	it('returns null meta for invalid id format', async () => {
+		const req = createMockRequest({ query: { userid: 'user1', id: 'dmm-tr' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data.meta).toBeNull();
+	});
+
+	it('returns torrent meta on success', async () => {
+		const mockData = { meta: { id: 'dmm-tr:123', type: 'other', name: 'Test Torrent' } };
+		mockGetTorrinDMMTorrent.mockResolvedValue({ data: mockData, status: 200 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', id: 'dmm-tr:123' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(200);
+		const data = res._getData() as any;
+		expect(data).toEqual(mockData);
+	});
+
+	it('returns error from helper', async () => {
+		mockGetTorrinDMMTorrent.mockResolvedValue({ error: 'Not found', status: 404 } as any);
+		const req = createMockRequest({ query: { userid: 'user1', id: 'dmm-tr:123' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(404);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/no-catalog/manifest.json.test.ts
+++ b/src/test/api/stremio-tr/[userid]/no-catalog/manifest.json.test.ts
@@ -1,0 +1,57 @@
+import handler from '@/pages/api/stremio-tr/[userid]/no-catalog/manifest.json';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+describe('/api/stremio-tr/[userid]/no-catalog/manifest.json', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		res = createMockResponse();
+	});
+
+	it('sets CORS header', async () => {
+		const req = createMockRequest({ query: { userid: 'test-user' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns production name when host includes debridmediamanager.com', async () => {
+		const req = createMockRequest({
+			query: { userid: 'test-user' },
+			headers: { host: 'debridmediamanager.com' },
+		});
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.name).toBe('DMM Cast for Torrin');
+	});
+
+	it('returns dev name when host does not include debridmediamanager.com', async () => {
+		const req = createMockRequest({
+			query: { userid: 'test-user' },
+			headers: { host: 'localhost:3000' },
+		});
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.name).toBe('[LOCAL] DMM Cast for Torrin (No Library)');
+	});
+
+	it('returns empty catalogs array', async () => {
+		const req = createMockRequest({
+			query: { userid: 'test-user' },
+			headers: { host: 'debridmediamanager.com' },
+		});
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.catalogs).toEqual([]);
+	});
+
+	it('returns correct manifest id', async () => {
+		const req = createMockRequest({
+			query: { userid: 'test-user' },
+			headers: { host: 'debridmediamanager.com' },
+		});
+		await handler(req, res);
+		const data = res._getData() as any;
+		expect(data.id).toBe('com.debridmediamanager.cast.torrin');
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/play/[link].test.ts
+++ b/src/test/api/stremio-tr/[userid]/play/[link].test.ts
@@ -1,0 +1,77 @@
+import handler from '@/pages/api/stremio-tr/[userid]/play/[link]';
+import { repository } from '@/services/repository';
+import { unrestrictTorrinLink } from '@/services/torrin';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/repository');
+vi.mock('@/services/torrin');
+
+const mockRepository = vi.mocked(repository);
+const mockUnrestrict = vi.mocked(unrestrictTorrinLink);
+
+const profile = { baseUrl: 'https://tr.test', apiKey: 'key' };
+
+describe('/api/stremio-tr/[userid]/play/[link]', () => {
+	let res: ReturnType<typeof createMockResponse>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		res = createMockResponse();
+		mockRepository.getTorrinCastProfile = vi.fn();
+	});
+
+	it('sets CORS + no-cache headers', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(null);
+		const req = createMockRequest({ query: { userid: 'user1', link: 'abc' } });
+		await handler(req, res);
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+		expect(res.setHeader).toHaveBeenCalledWith(
+			'Cache-Control',
+			'no-store, no-cache, must-revalidate'
+		);
+	});
+
+	it('returns 400 when userid or link is missing', async () => {
+		const req = createMockRequest({ query: { userid: 'user1' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 500 when no profile found', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(null);
+		const req = createMockRequest({ query: { userid: 'user1', link: 'abc' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+
+	it('unrestricts the decoded link and redirects on success', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(profile);
+		mockUnrestrict.mockResolvedValue({ download: 'https://stream.test/v.mkv' } as any);
+		const link = encodeURIComponent('https://tr.test/d/xyz');
+		const req = createMockRequest({ query: { userid: 'user1', link } });
+		await handler(req, res);
+		expect(mockUnrestrict).toHaveBeenCalledWith(
+			'https://tr.test',
+			'key',
+			'https://tr.test/d/xyz'
+		);
+		expect(res.redirect).toHaveBeenCalledWith('https://stream.test/v.mkv');
+	});
+
+	it('returns 500 when unrestrict returns no download', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(profile);
+		mockUnrestrict.mockResolvedValue({ download: '' } as any);
+		const req = createMockRequest({ query: { userid: 'user1', link: 'abc' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+
+	it('returns 500 on unrestrict error', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(profile);
+		mockUnrestrict.mockRejectedValue(new Error('boom'));
+		const req = createMockRequest({ query: { userid: 'user1', link: 'abc' } });
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].test.ts
@@ -1,0 +1,174 @@
+import handler from '@/pages/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid]';
+import { repository } from '@/services/repository';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import type { Mock } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/repository');
+
+const mockRepository = vi.mocked(repository);
+
+describe('/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid]', () => {
+	const originalOrigin = process.env.DMM_ORIGIN;
+
+	beforeEach(() => {
+		process.env.DMM_ORIGIN = 'https://dmm.test';
+		vi.clearAllMocks();
+		mockRepository.getTorrinCastProfile = vi.fn();
+		mockRepository.getTorrinUserCastStreams = vi.fn();
+		mockRepository.getTorrinOtherStreams = vi.fn();
+		mockRepository.getSnapshotsByHashes = vi.fn().mockResolvedValue([]);
+	});
+
+	afterAll(() => {
+		process.env.DMM_ORIGIN = originalOrigin;
+	});
+
+	const setupProfile = (overrides: Record<string, unknown> = {}) => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue({
+			baseUrl: 'https://tr.test',
+			apiKey: 'tr-key',
+			movieMaxSize: 0,
+			episodeMaxSize: 0,
+			otherStreamsLimit: 5,
+			hideCastOption: false,
+			...overrides,
+		});
+	};
+
+	const userStream = {
+		url: 'https://files.dmm.test/MyMovie.mkv',
+		link: 'https://tr.test/d/aaa',
+		hash: 'userhash1234',
+		size: 5120,
+		filename: 'MyMovie.mkv',
+	};
+
+	const otherStream = {
+		url: 'https://files.dmm.test/OtherMovie.mkv',
+		link: 'https://tr.test/d/bbb',
+		hash: 'otherhash5678',
+		size: 3072,
+		filename: 'OtherMovie.mkv',
+	};
+
+	it('validates query parameters', async () => {
+		const req = createMockRequest({ query: { userid: 'user', mediaType: 'movie' } });
+		const res = createMockResponse();
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 500 when no profile exists', async () => {
+		mockRepository.getTorrinCastProfile = vi.fn().mockResolvedValue(null);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		expect(res.status).toHaveBeenCalledWith(500);
+	});
+
+	it('uses movieMaxSize for movies', async () => {
+		setupProfile({ movieMaxSize: 15, episodeMaxSize: 3 });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith('tt111', 'user1', 5, 15);
+	});
+
+	it('uses episodeMaxSize for shows and strips .json', async () => {
+		setupProfile({ movieMaxSize: 15, episodeMaxSize: 3 });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'series', imdbid: 'tt111:1:2.json' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith(
+			'tt111:1:2',
+			'user1',
+			5,
+			3
+		);
+	});
+
+	it('clamps otherStreamsLimit above 5 to 5', async () => {
+		setupProfile({ otherStreamsLimit: 99 });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith(
+			'tt111',
+			'user1',
+			5,
+			undefined
+		);
+	});
+
+	it('hideCastOption hides the cast stream entry', async () => {
+		setupProfile({ hideCastOption: true });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([userStream]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		const payload = (res.json as Mock).mock.calls[0][0];
+		const castOption = payload.streams.find((s: any) => s.name === 'DMM Cast TR✨');
+		expect(castOption).toBeUndefined();
+		expect(payload.streams).toHaveLength(1);
+	});
+
+	it('shows cast option when hideCastOption is false', async () => {
+		setupProfile({ hideCastOption: false });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		const payload = (res.json as Mock).mock.calls[0][0];
+		expect(payload.streams.find((s: any) => s.name === 'DMM Cast TR✨')).toBeDefined();
+	});
+
+	it('combines cast option, user, and other streams', async () => {
+		setupProfile({ otherStreamsLimit: 2, movieMaxSize: 30 });
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([userStream]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([otherStream]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		const payload = (res.json as Mock).mock.calls[0][0];
+		expect(payload.streams).toHaveLength(3);
+	});
+
+	it('builds play URLs from the encoded link', async () => {
+		setupProfile();
+		mockRepository.getTorrinUserCastStreams = vi.fn().mockResolvedValue([userStream]);
+		mockRepository.getTorrinOtherStreams = vi.fn().mockResolvedValue([]);
+		const req = createMockRequest({
+			query: { userid: 'user1', mediaType: 'movie', imdbid: 'tt111' },
+		});
+		const res = createMockResponse();
+		await handler(req, res);
+		const payload = (res.json as Mock).mock.calls[0][0];
+		const playStream = payload.streams.find((s: any) => s.url);
+		expect(playStream.url).toBe(
+			`https://dmm.test/api/stremio-tr/user1/play/${encodeURIComponent(userStream.link)}`
+		);
+	});
+});

--- a/src/test/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid].test.ts
@@ -78,7 +78,13 @@ describe('/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid]', () => {
 		});
 		const res = createMockResponse();
 		await handler(req, res);
-		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith('tt111', 'user1', 5, 15);
+		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith(
+			'tt111',
+			'user1',
+			'https://tr.test',
+			5,
+			15
+		);
 	});
 
 	it('uses episodeMaxSize for shows and strips .json', async () => {
@@ -93,6 +99,7 @@ describe('/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid]', () => {
 		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith(
 			'tt111:1:2',
 			'user1',
+			'https://tr.test',
 			5,
 			3
 		);
@@ -110,6 +117,7 @@ describe('/api/stremio-tr/[userid]/stream/[mediaType]/[imdbid]', () => {
 		expect(mockRepository.getTorrinOtherStreams).toHaveBeenCalledWith(
 			'tt111',
 			'user1',
+			'https://tr.test',
 			5,
 			undefined
 		);

--- a/src/test/api/stremio-tr/cast/library/[torrentIdPlusHash].test.ts
+++ b/src/test/api/stremio-tr/cast/library/[torrentIdPlusHash].test.ts
@@ -106,7 +106,8 @@ describe('/api/stremio-tr/cast/library/[torrentIdPlusHash]', () => {
 			'hash123',
 			'Movie.2024.mkv',
 			'https://tr/link-1',
-			1
+			1,
+			'https://tr.test'
 		);
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith(

--- a/src/test/api/stremio-tr/cast/library/[torrentIdPlusHash].test.ts
+++ b/src/test/api/stremio-tr/cast/library/[torrentIdPlusHash].test.ts
@@ -1,0 +1,144 @@
+import handler from '@/pages/api/stremio-tr/cast/library/[torrentIdPlusHash]';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+	mockGetTorrentInfo,
+	mockDbGetIMDBIdByHash,
+	mockDbSaveCast,
+	mockDbSaveIMDBIdMapping,
+	mockGenerateUserId,
+} = vi.hoisted(() => ({
+	mockGetTorrentInfo: vi.fn(),
+	mockDbGetIMDBIdByHash: vi.fn(),
+	mockDbSaveCast: vi.fn(),
+	mockDbSaveIMDBIdMapping: vi.fn(),
+	mockGenerateUserId: vi.fn(),
+}));
+
+vi.mock('@/services/torrin', () => ({
+	getTorrinTorrentInfo: mockGetTorrentInfo,
+}));
+
+vi.mock('@/services/repository', () => ({
+	repository: {
+		getIMDBIdByHash: mockDbGetIMDBIdByHash,
+		saveTorrinCast: mockDbSaveCast,
+		saveIMDBIdMapping: mockDbSaveIMDBIdMapping,
+	},
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => ({
+	generateTorrinUserId: mockGenerateUserId,
+}));
+
+const makeTorrentInfo = (overrides: Partial<any> = {}) => ({
+	id: 'trid1',
+	hash: 'hash123',
+	filename: 'Movie.2024',
+	original_filename: 'Movie.2024',
+	files: [
+		{ id: 1, path: 'Movie.2024.mkv', bytes: 1048576, selected: 1 },
+		{ id: 2, path: 'Extra.mkv', bytes: 2097152, selected: 1 },
+	],
+	links: ['https://tr/link-1', 'https://tr/link-2'],
+	...overrides,
+});
+
+const creds = { baseUrl: 'https://tr.test', apiKey: 'tr-key' };
+
+describe('/api/stremio-tr/cast/library/[torrentIdPlusHash]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateUserId.mockResolvedValue('tr-user-1');
+		mockDbGetIMDBIdByHash.mockResolvedValue('tt1234567');
+		mockGetTorrentInfo.mockResolvedValue(makeTorrentInfo());
+		mockDbSaveIMDBIdMapping.mockResolvedValue(undefined);
+	});
+
+	it('validates creds', async () => {
+		const req = createMockRequest({ query: { torrentIdPlusHash: '1:hash' } });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('validates torrentIdPlusHash', async () => {
+		const req = createMockRequest({ query: { ...creds } });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('returns 400 when selected files and links mismatch', async () => {
+		mockGetTorrentInfo.mockResolvedValue(makeTorrentInfo({ links: ['https://tr/link-1'] }));
+		const req = createMockRequest({
+			query: { torrentIdPlusHash: 'trid1:hash123', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+		expect(res.json).toHaveBeenCalledWith({
+			status: 'error',
+			errorMessage: 'Cannot determine file link',
+		});
+	});
+
+	it('saves a cast per selected file and returns success', async () => {
+		const req = createMockRequest({
+			query: { torrentIdPlusHash: 'trid1:hash123', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockGetTorrentInfo).toHaveBeenCalledWith('https://tr.test', 'tr-key', 'trid1');
+		expect(mockDbSaveCast).toHaveBeenCalledTimes(2);
+		expect(mockDbSaveCast).toHaveBeenCalledWith(
+			'tt1234567',
+			'tr-user-1',
+			'hash123',
+			'Movie.2024.mkv',
+			'https://tr/link-1',
+			1
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 'success', imdbId: 'tt1234567' })
+		);
+	});
+
+	it('requests an imdb id when none is known', async () => {
+		mockDbGetIMDBIdByHash.mockResolvedValue('');
+		const req = createMockRequest({
+			query: { torrentIdPlusHash: 'trid1:hash123', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ status: 'need_imdb_id' }));
+		expect(mockDbSaveCast).not.toHaveBeenCalled();
+	});
+
+	it('saves a user-provided imdb id mapping', async () => {
+		mockDbGetIMDBIdByHash.mockResolvedValue('');
+		const req = createMockRequest({
+			query: { torrentIdPlusHash: 'trid1:hash123', imdbId: 'tt7654321', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockDbSaveIMDBIdMapping).toHaveBeenCalledWith('hash123', 'tt7654321');
+		expect(mockDbSaveCast).toHaveBeenCalled();
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+});

--- a/src/test/api/stremio-tr/cast/movie/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/cast/movie/[imdbid].test.ts
@@ -1,0 +1,102 @@
+import handler from '@/pages/api/stremio-tr/cast/movie/[imdbid]';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSaveCast, mockGenerateUserId, mockGetBiggestFile } = vi.hoisted(() => ({
+	mockSaveCast: vi.fn(),
+	mockGenerateUserId: vi.fn(),
+	mockGetBiggestFile: vi.fn(),
+}));
+
+vi.mock('@/services/repository', () => ({
+	repository: {
+		saveTorrinCast: mockSaveCast,
+	},
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => ({
+	generateTorrinUserId: mockGenerateUserId,
+}));
+
+vi.mock('@/utils/getTorrinStreamUrl', () => ({
+	getBiggestFileTorrinStreamUrl: mockGetBiggestFile,
+}));
+
+const creds = { baseUrl: 'https://tr.test', apiKey: 'tr-key' };
+
+describe('/api/stremio-tr/cast/movie/[imdbid]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('validates required parameters', async () => {
+		const req = createMockRequest({ query: { imdbid: 'tt123', ...creds } });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('grabs the biggest file, saves the cast, and returns success', async () => {
+		mockGenerateUserId.mockResolvedValue('tr-user-1');
+		mockGetBiggestFile.mockResolvedValue([
+			'https://files.example.com/Video.mkv',
+			'https://tr.test/d/link',
+			900,
+		]);
+
+		const req = createMockRequest({
+			query: { imdbid: 'tt1234567', hash: 'hashabc', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockGetBiggestFile).toHaveBeenCalledWith('https://tr.test', 'tr-key', 'hashabc');
+		expect(mockGenerateUserId).toHaveBeenCalledWith('https://tr.test', 'tr-key');
+		expect(mockSaveCast).toHaveBeenCalledWith(
+			'tt1234567',
+			'tr-user-1',
+			'hashabc',
+			'https://files.example.com/Video.mkv',
+			'https://tr.test/d/link',
+			900
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({
+			status: 'success',
+			message: 'You can now stream the movie in Stremio',
+			filename: 'Video.mkv',
+		});
+	});
+
+	it('returns 500 when no streamable file is found', async () => {
+		mockGetBiggestFile.mockResolvedValue(['', '', 0]);
+		const req = createMockRequest({
+			query: { imdbid: 'tt1', hash: 'hashabc', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(500);
+		expect(mockSaveCast).not.toHaveBeenCalled();
+	});
+
+	it('returns 500 when stream acquisition throws', async () => {
+		mockGetBiggestFile.mockRejectedValue(new Error('tr offline'));
+		const req = createMockRequest({
+			query: { imdbid: 'tt7654321', hash: 'hashabc', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(500);
+		expect(res.json).toHaveBeenCalledWith({
+			status: 'error',
+			errorMessage: 'tr offline',
+		});
+	});
+});

--- a/src/test/api/stremio-tr/cast/movie/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/cast/movie/[imdbid].test.ts
@@ -61,7 +61,8 @@ describe('/api/stremio-tr/cast/movie/[imdbid]', () => {
 			'hashabc',
 			'https://files.example.com/Video.mkv',
 			'https://tr.test/d/link',
-			900
+			900,
+			'https://tr.test'
 		);
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith({
@@ -96,7 +97,7 @@ describe('/api/stremio-tr/cast/movie/[imdbid]', () => {
 		expect(res.status).toHaveBeenCalledWith(500);
 		expect(res.json).toHaveBeenCalledWith({
 			status: 'error',
-			errorMessage: 'tr offline',
+			errorMessage: 'Failed to cast the movie',
 		});
 	});
 });

--- a/src/test/api/stremio-tr/cast/saveProfile.test.ts
+++ b/src/test/api/stremio-tr/cast/saveProfile.test.ts
@@ -1,0 +1,156 @@
+import handler from '@/pages/api/stremio-tr/cast/saveProfile';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockValidateApiKey, mockGenerateUserId, mockSaveCastProfile } = vi.hoisted(() => ({
+	mockValidateApiKey: vi.fn(),
+	mockGenerateUserId: vi.fn(),
+	mockSaveCastProfile: vi.fn(),
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => ({
+	validateTorrinApiKey: mockValidateApiKey,
+	generateTorrinUserId: mockGenerateUserId,
+}));
+
+vi.mock('@/services/repository', () => ({
+	repository: {
+		saveTorrinCastProfile: mockSaveCastProfile,
+	},
+}));
+
+const creds = { baseUrl: 'https://tr.test', apiKey: 'tr-key' };
+
+describe('/api/stremio-tr/cast/saveProfile', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockValidateApiKey.mockResolvedValue({ valid: true });
+		mockGenerateUserId.mockResolvedValue('tr-user-1');
+		mockSaveCastProfile.mockResolvedValue({
+			userId: 'tr-user-1',
+			movieMaxSize: 0,
+			episodeMaxSize: 0,
+			otherStreamsLimit: 5,
+			hideCastOption: false,
+		});
+	});
+
+	it('rejects non-POST methods', async () => {
+		const req = createMockRequest({ method: 'GET' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(405);
+	});
+
+	it('validates creds are present', async () => {
+		const req = createMockRequest({ method: 'POST', body: {} });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('rejects invalid credentials', async () => {
+		mockValidateApiKey.mockResolvedValue({ valid: false });
+		const req = createMockRequest({ method: 'POST', body: creds });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(401);
+	});
+
+	it('saves profile without settings', async () => {
+		const req = createMockRequest({ method: 'POST', body: creds });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockSaveCastProfile).toHaveBeenCalledWith(
+			'tr-user-1',
+			'https://tr.test',
+			'tr-key',
+			undefined,
+			undefined,
+			undefined,
+			undefined
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it('saves profile with all settings', async () => {
+		const req = createMockRequest({
+			method: 'POST',
+			body: {
+				...creds,
+				movieMaxSize: 15,
+				episodeMaxSize: 3,
+				otherStreamsLimit: 2,
+				hideCastOption: true,
+			},
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockSaveCastProfile).toHaveBeenCalledWith(
+			'tr-user-1',
+			'https://tr.test',
+			'tr-key',
+			15,
+			3,
+			2,
+			true
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+	});
+
+	it('validates otherStreamsLimit range', async () => {
+		const req = createMockRequest({
+			method: 'POST',
+			body: { ...creds, otherStreamsLimit: 10 },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+		expect(mockSaveCastProfile).not.toHaveBeenCalled();
+	});
+
+	it('rejects non-integer otherStreamsLimit', async () => {
+		const req = createMockRequest({
+			method: 'POST',
+			body: { ...creds, otherStreamsLimit: 2.5 },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('accepts otherStreamsLimit of 0', async () => {
+		const req = createMockRequest({
+			method: 'POST',
+			body: { ...creds, otherStreamsLimit: 0 },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(mockSaveCastProfile).toHaveBeenCalledWith(
+			'tr-user-1',
+			'https://tr.test',
+			'tr-key',
+			undefined,
+			undefined,
+			0,
+			undefined
+		);
+	});
+});

--- a/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
@@ -1,0 +1,98 @@
+import handler from '@/pages/api/stremio-tr/cast/series/[imdbid]';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockSaveCast, mockGenerateUserId, mockGetStreamUrl } = vi.hoisted(() => ({
+	mockSaveCast: vi.fn(),
+	mockGenerateUserId: vi.fn(),
+	mockGetStreamUrl: vi.fn(),
+}));
+
+vi.mock('@/services/repository', () => ({
+	repository: {
+		saveTorrinCast: mockSaveCast,
+	},
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => ({
+	generateTorrinUserId: mockGenerateUserId,
+}));
+
+vi.mock('@/utils/getTorrinStreamUrl', () => ({
+	getTorrinStreamUrl: mockGetStreamUrl,
+}));
+
+const creds = { baseUrl: 'https://tr.test', apiKey: 'tr-key' };
+
+describe('/api/stremio-tr/cast/series/[imdbid]', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGenerateUserId.mockResolvedValue('tr-user-1');
+	});
+
+	it('validates required params', async () => {
+		const req = createMockRequest({ query: { imdbid: 'tt123', ...creds } });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
+	it('casts each requested file id and records success', async () => {
+		mockGetStreamUrl.mockResolvedValue([
+			'https://files.example.com/Video-S01E02.mkv',
+			'https://tr.test/d/link',
+			1,
+			2,
+			700,
+		]);
+		const req = createMockRequest({
+			query: { imdbid: 'tt999', hash: 'hash', fileIds: '101', ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockGetStreamUrl).toHaveBeenCalledWith(
+			'https://tr.test',
+			'tr-key',
+			'hash',
+			101,
+			'tv'
+		);
+		expect(mockSaveCast).toHaveBeenCalledWith(
+			'tt999:1:2',
+			'tr-user-1',
+			'hash',
+			'https://files.example.com/Video-S01E02.mkv',
+			'https://tr.test/d/link',
+			700
+		);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ errorEpisodes: [] });
+	});
+
+	it('tracks episodes that fail to cast', async () => {
+		mockGetStreamUrl
+			.mockResolvedValueOnce([
+				'https://files.example.com/Video-S01E01.mkv',
+				'https://tr.test/d/1',
+				1,
+				1,
+				600,
+			])
+			.mockRejectedValueOnce(new Error('tr offline'));
+
+		const req = createMockRequest({
+			query: { imdbid: 'tt777', hash: 'hash', fileIds: ['201', '202'], ...creds },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockSaveCast).toHaveBeenCalledTimes(1);
+		expect(res.status).toHaveBeenCalledWith(200);
+		expect(res.json).toHaveBeenCalledWith({ errorEpisodes: ['fileId:202'] });
+	});
+});

--- a/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
@@ -72,7 +72,8 @@ describe('/api/stremio-tr/cast/series/[imdbid]', () => {
 			'hash',
 			'https://files.example.com/Video-S01E02.mkv',
 			'https://tr.test/d/link',
-			700
+			700,
+			'https://tr.test'
 		);
 		expect(res.status).toHaveBeenCalledWith(200);
 		expect(res.json).toHaveBeenCalledWith({ errorEpisodes: [] });

--- a/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
+++ b/src/test/api/stremio-tr/cast/series/[imdbid].test.ts
@@ -2,11 +2,14 @@ import handler from '@/pages/api/stremio-tr/cast/series/[imdbid]';
 import { createMockRequest, createMockResponse } from '@/test/utils/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockSaveCast, mockGenerateUserId, mockGetStreamUrl } = vi.hoisted(() => ({
-	mockSaveCast: vi.fn(),
-	mockGenerateUserId: vi.fn(),
-	mockGetStreamUrl: vi.fn(),
-}));
+const { mockSaveCast, mockGenerateUserId, mockGetStreamUrl, mockValidateApiKey } = vi.hoisted(
+	() => ({
+		mockSaveCast: vi.fn(),
+		mockGenerateUserId: vi.fn(),
+		mockGetStreamUrl: vi.fn(),
+		mockValidateApiKey: vi.fn(),
+	})
+);
 
 vi.mock('@/services/repository', () => ({
 	repository: {
@@ -16,6 +19,7 @@ vi.mock('@/services/repository', () => ({
 
 vi.mock('@/utils/torrinCastApiHelpers', () => ({
 	generateTorrinUserId: mockGenerateUserId,
+	validateTorrinApiKey: mockValidateApiKey,
 }));
 
 vi.mock('@/utils/getTorrinStreamUrl', () => ({
@@ -28,6 +32,7 @@ describe('/api/stremio-tr/cast/series/[imdbid]', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockGenerateUserId.mockResolvedValue('tr-user-1');
+		mockValidateApiKey.mockResolvedValue({ valid: true });
 	});
 
 	it('validates required params', async () => {

--- a/src/test/api/stremio-tr/cast/updateSizeLimits.test.ts
+++ b/src/test/api/stremio-tr/cast/updateSizeLimits.test.ts
@@ -132,7 +132,7 @@ describe('API /api/stremio-tr/cast/updateSizeLimits', () => {
 		expect(res._getStatusCode()).toBe(500);
 		expect(res._getData()).toEqual({
 			status: 'error',
-			errorMessage: 'Service unavailable',
+			errorMessage: 'Failed to update size limits',
 		});
 	});
 });

--- a/src/test/api/stremio-tr/cast/updateSizeLimits.test.ts
+++ b/src/test/api/stremio-tr/cast/updateSizeLimits.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockHelpers = vi.hoisted(() => ({
+	validateTorrinApiKey: vi.fn(),
+	generateTorrinUserId: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+	saveTorrinCastProfile: vi.fn(),
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => mockHelpers);
+vi.mock('@/services/repository', () => ({ repository: mockDb }));
+
+import handler from '@/pages/api/stremio-tr/cast/updateSizeLimits';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+
+const creds = { baseUrl: 'https://tr.test', apiKey: 'valid-key' };
+const validProfile = {
+	userId: 'tr-user-456',
+	movieMaxSize: 5000,
+	episodeMaxSize: 2000,
+	otherStreamsLimit: 3,
+	hideCastOption: false,
+};
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('API /api/stremio-tr/cast/updateSizeLimits', () => {
+	it('sets CORS header', async () => {
+		const req = createMockRequest({ method: 'GET' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 405 for non-POST methods', async () => {
+		const req = createMockRequest({ method: 'GET' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Allow', ['POST']);
+		expect(res._getStatusCode()).toBe(405);
+	});
+
+	it('returns 400 when creds are missing', async () => {
+		const req = createMockRequest({ method: 'POST', body: {} });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+	});
+
+	it('returns 400 when otherStreamsLimit is out of range', async () => {
+		const req = createMockRequest({
+			method: 'POST',
+			body: { ...creds, otherStreamsLimit: 6 },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'otherStreamsLimit must be an integer between 0 and 5',
+		});
+	});
+
+	it('returns 401 when credentials are invalid', async () => {
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: false });
+		const req = createMockRequest({ method: 'POST', body: creds });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(401);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Invalid Torrin credentials',
+		});
+	});
+
+	it('saves profile and returns success', async () => {
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: true });
+		mockHelpers.generateTorrinUserId.mockResolvedValue('tr-user-456');
+		mockDb.saveTorrinCastProfile.mockResolvedValue(validProfile);
+		const req = createMockRequest({
+			method: 'POST',
+			body: {
+				...creds,
+				movieMaxSize: 5000,
+				episodeMaxSize: 2000,
+				otherStreamsLimit: 3,
+				hideCastOption: false,
+			},
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockDb.saveTorrinCastProfile).toHaveBeenCalledWith(
+			'tr-user-456',
+			'https://tr.test',
+			'valid-key',
+			5000,
+			2000,
+			3,
+			false
+		);
+		expect(res._getStatusCode()).toBe(200);
+		expect(res._getData()).toEqual({
+			status: 'success',
+			profile: validProfile,
+		});
+	});
+
+	it('returns 500 on error', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		mockHelpers.validateTorrinApiKey.mockRejectedValue(new Error('Service unavailable'));
+		const req = createMockRequest({ method: 'POST', body: creds });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(500);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Service unavailable',
+		});
+	});
+});

--- a/src/test/api/stremio-tr/deletelink.test.ts
+++ b/src/test/api/stremio-tr/deletelink.test.ts
@@ -116,7 +116,7 @@ describe('API /api/stremio-tr/deletelink', () => {
 		expect(res._getStatusCode()).toBe(500);
 		expect(res._getData()).toEqual({
 			status: 'error',
-			errorMessage: 'DB down',
+			errorMessage: 'Failed to delete link',
 		});
 	});
 });

--- a/src/test/api/stremio-tr/deletelink.test.ts
+++ b/src/test/api/stremio-tr/deletelink.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockHelpers = vi.hoisted(() => ({
+	validateTorrinApiKey: vi.fn(),
+	generateTorrinUserId: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+	deleteTorrinCastedLink: vi.fn(),
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => mockHelpers);
+vi.mock('@/services/repository', () => ({ repository: mockDb }));
+
+import handler from '@/pages/api/stremio-tr/deletelink';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+const validBody = {
+	baseUrl: 'https://tr.test',
+	apiKey: 'valid-key',
+	imdbId: 'tt123',
+	hash: 'abc',
+};
+
+describe('API /api/stremio-tr/deletelink', () => {
+	it('sets CORS header', async () => {
+		const req = createMockRequest({ method: 'GET' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 405 for non-DELETE methods', async () => {
+		const req = createMockRequest({ method: 'GET' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Allow', ['DELETE']);
+		expect(res._getStatusCode()).toBe(405);
+	});
+
+	it('returns 400 when creds are missing', async () => {
+		const req = createMockRequest({
+			method: 'DELETE',
+			body: { imdbId: 'tt1', hash: 'abc' },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+	});
+
+	it('returns 400 when imdbId or hash is missing', async () => {
+		const req = createMockRequest({
+			method: 'DELETE',
+			body: { baseUrl: 'https://tr.test', apiKey: 'valid-key' },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Missing or invalid "imdbId" or "hash" in request body',
+		});
+	});
+
+	it('returns 401 when credentials are invalid', async () => {
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: false });
+		const req = createMockRequest({ method: 'DELETE', body: validBody });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(401);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Invalid Torrin credentials',
+		});
+	});
+
+	it('deletes the link on success', async () => {
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: true });
+		mockHelpers.generateTorrinUserId.mockResolvedValue('tr-user-456');
+		mockDb.deleteTorrinCastedLink.mockResolvedValue(undefined);
+		const req = createMockRequest({ method: 'DELETE', body: validBody });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockDb.deleteTorrinCastedLink).toHaveBeenCalledWith('tt123', 'tr-user-456', 'abc');
+		expect(res._getStatusCode()).toBe(200);
+		expect(res._getData()).toEqual({
+			status: 'success',
+			message: 'Link deleted successfully',
+		});
+	});
+
+	it('returns 500 on error', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		mockHelpers.validateTorrinApiKey.mockRejectedValue(new Error('DB down'));
+		const req = createMockRequest({ method: 'DELETE', body: validBody });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(500);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'DB down',
+		});
+	});
+});

--- a/src/test/api/stremio-tr/id.test.ts
+++ b/src/test/api/stremio-tr/id.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockHelpers = vi.hoisted(() => ({
+	validateMethod: vi.fn(),
+	validateTorrinCreds: vi.fn(),
+	generateTorrinUserId: vi.fn(),
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => mockHelpers);
+
+import handler from '@/pages/api/stremio-tr/id';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('API /api/stremio-tr/id', () => {
+	it('sets CORS header', async () => {
+		mockHelpers.validateMethod.mockReturnValue(false);
+		const req = createMockRequest();
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns early when validateMethod fails', async () => {
+		mockHelpers.validateMethod.mockReturnValue(false);
+		const req = createMockRequest({ method: 'POST' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockHelpers.validateMethod).toHaveBeenCalledWith(req, res, ['GET']);
+		expect(mockHelpers.validateTorrinCreds).not.toHaveBeenCalled();
+	});
+
+	it('returns early when validateTorrinCreds fails', async () => {
+		mockHelpers.validateMethod.mockReturnValue(true);
+		mockHelpers.validateTorrinCreds.mockReturnValue(null);
+		const req = createMockRequest();
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockHelpers.validateTorrinCreds).toHaveBeenCalledWith(req, res);
+		expect(mockHelpers.generateTorrinUserId).not.toHaveBeenCalled();
+	});
+
+	it('returns user ID on success', async () => {
+		mockHelpers.validateMethod.mockReturnValue(true);
+		mockHelpers.validateTorrinCreds.mockReturnValue({
+			baseUrl: 'https://tr.test',
+			apiKey: 'test-key',
+		});
+		mockHelpers.generateTorrinUserId.mockResolvedValue('tr-user-456');
+		const req = createMockRequest();
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockHelpers.generateTorrinUserId).toHaveBeenCalledWith(
+			'https://tr.test',
+			'test-key'
+		);
+		expect(res._getStatusCode()).toBe(200);
+		expect(res._getData()).toEqual({ id: 'tr-user-456' });
+	});
+
+	it('returns 500 on error with Error instance', async () => {
+		mockHelpers.validateMethod.mockReturnValue(true);
+		mockHelpers.validateTorrinCreds.mockReturnValue({
+			baseUrl: 'https://tr.test',
+			apiKey: 'test-key',
+		});
+		mockHelpers.generateTorrinUserId.mockRejectedValue(new Error('API failure'));
+		const req = createMockRequest();
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(500);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'API failure',
+		});
+	});
+
+	it('returns 500 with Unknown error for non-Error throws', async () => {
+		mockHelpers.validateMethod.mockReturnValue(true);
+		mockHelpers.validateTorrinCreds.mockReturnValue({
+			baseUrl: 'https://tr.test',
+			apiKey: 'test-key',
+		});
+		mockHelpers.generateTorrinUserId.mockRejectedValue('string error');
+		const req = createMockRequest();
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(500);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Unknown error',
+		});
+	});
+});

--- a/src/test/api/stremio-tr/id.test.ts
+++ b/src/test/api/stremio-tr/id.test.ts
@@ -84,7 +84,7 @@ describe('API /api/stremio-tr/id', () => {
 		expect(res._getStatusCode()).toBe(500);
 		expect(res._getData()).toEqual({
 			status: 'error',
-			errorMessage: 'API failure',
+			errorMessage: 'Failed to generate user ID',
 		});
 	});
 
@@ -103,7 +103,7 @@ describe('API /api/stremio-tr/id', () => {
 		expect(res._getStatusCode()).toBe(500);
 		expect(res._getData()).toEqual({
 			status: 'error',
-			errorMessage: 'Unknown error',
+			errorMessage: 'Failed to generate user ID',
 		});
 	});
 });

--- a/src/test/api/stremio-tr/links.test.ts
+++ b/src/test/api/stremio-tr/links.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockHelpers = vi.hoisted(() => ({
+	validateTorrinApiKey: vi.fn(),
+	generateTorrinUserId: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+	fetchAllTorrinCastedLinks: vi.fn(),
+}));
+
+vi.mock('@/utils/torrinCastApiHelpers', () => mockHelpers);
+vi.mock('@/services/repository', () => ({ repository: mockDb }));
+
+import handler from '@/pages/api/stremio-tr/links';
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+const validQuery = { baseUrl: 'https://tr.test', apiKey: 'valid-key' };
+
+describe('API /api/stremio-tr/links', () => {
+	it('sets CORS header', async () => {
+		const req = createMockRequest({ method: 'POST' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('access-control-allow-origin', '*');
+	});
+
+	it('returns 405 for non-GET methods', async () => {
+		const req = createMockRequest({ method: 'POST' });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Allow', ['GET']);
+		expect(res._getStatusCode()).toBe(405);
+	});
+
+	it('returns 400 when creds are missing', async () => {
+		const req = createMockRequest({ method: 'GET', query: {} });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+	});
+
+	it('returns 400 when apiKey is not a string', async () => {
+		const req = createMockRequest({
+			method: 'GET',
+			query: { baseUrl: 'https://tr.test', apiKey: ['a', 'b'] },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(400);
+	});
+
+	it('returns 401 when credentials are invalid', async () => {
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: false });
+		const req = createMockRequest({
+			method: 'GET',
+			query: { baseUrl: 'https://tr.test', apiKey: 'bad-key' },
+		});
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(401);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'Invalid Torrin credentials',
+		});
+	});
+
+	it('returns links on success', async () => {
+		const links = [{ imdbId: 'tt1', url: 'http://example.com' }];
+		mockHelpers.validateTorrinApiKey.mockResolvedValue({ valid: true });
+		mockHelpers.generateTorrinUserId.mockResolvedValue('tr-user-456');
+		mockDb.fetchAllTorrinCastedLinks.mockResolvedValue(links);
+		const req = createMockRequest({ method: 'GET', query: validQuery });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(mockHelpers.generateTorrinUserId).toHaveBeenCalledWith(
+			'https://tr.test',
+			'valid-key'
+		);
+		expect(mockDb.fetchAllTorrinCastedLinks).toHaveBeenCalledWith('tr-user-456');
+		expect(res._getStatusCode()).toBe(200);
+		expect(res._getData()).toEqual({ status: 'success', links });
+	});
+
+	it('returns 500 on error', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		mockHelpers.validateTorrinApiKey.mockRejectedValue(new Error('DB down'));
+		const req = createMockRequest({ method: 'GET', query: validQuery });
+		const res = createMockResponse();
+
+		await handler(req, res);
+
+		expect(res._getStatusCode()).toBe(500);
+		expect(res._getData()).toEqual({
+			status: 'error',
+			errorMessage: 'DB down',
+		});
+	});
+});

--- a/src/test/api/stremio-tr/links.test.ts
+++ b/src/test/api/stremio-tr/links.test.ts
@@ -109,7 +109,7 @@ describe('API /api/stremio-tr/links', () => {
 		expect(res._getStatusCode()).toBe(500);
 		expect(res._getData()).toEqual({
 			status: 'error',
-			errorMessage: 'DB down',
+			errorMessage: 'Failed to fetch casted links',
 		});
 	});
 });

--- a/src/test/api/stremio/[userid]/meta/other/[id].test.ts
+++ b/src/test/api/stremio/[userid]/meta/other/[id].test.ts
@@ -124,6 +124,19 @@ describe('/api/stremio/[userid]/meta/other/[id]', () => {
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 
+	it.each(['dmm-ad:1', 'dmm-tb:1', 'dmm-tr:1'])(
+		'skips non-RD id %s so the owning addon handles it',
+		async (id) => {
+			const req = createMockRequest({ query: { userid: 'user', id } });
+			const res = createMockResponse();
+
+			await handler(req, res);
+
+			expect(res.json).toHaveBeenCalledWith({ meta: null });
+			expect(mockGetDMMTorrent).not.toHaveBeenCalled();
+		}
+	);
+
 	it('returns upgrade notice for legacy tokens', async () => {
 		mockIsLegacyToken.mockReturnValue(true);
 		const req = createMockRequest({ query: { userid: 'abcde', id: 'dmm:1' } });

--- a/src/test/pages/hashlist.client.test.tsx
+++ b/src/test/pages/hashlist.client.test.tsx
@@ -29,6 +29,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: vi.fn(() => [null, false, false]),
 	useAllDebridApiKey: vi.fn(() => null),
 	useTorBoxAccessToken: vi.fn(() => null),
+	useTorrinCreds: vi.fn(() => [null, null]),
 }));
 
 vi.mock('@/contexts/LibraryCacheContext', () => ({

--- a/src/test/pages/index.client.test.tsx
+++ b/src/test/pages/index.client.test.tsx
@@ -55,7 +55,9 @@ vi.mock('@/hooks/auth', () => ({
 		loginWithRealDebrid: vi.fn(),
 		loginWithAllDebrid: vi.fn(),
 		loginWithTorbox: vi.fn(),
+		loginWithTorrin: vi.fn(),
 	}),
+	useTorrinCreds: () => [null, null],
 }));
 
 vi.mock('@/hooks/castToken', () => ({

--- a/src/test/pages/library-addMagnet.client.test.tsx
+++ b/src/test/pages/library-addMagnet.client.test.tsx
@@ -52,6 +52,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: () => ['test-rd-key'],
 	useAllDebridApiKey: () => 'test-ad-key',
 	useTorBoxAccessToken: () => 'test-tb-key',
+	useTorrinCreds: () => [null, null],
 }));
 
 vi.mock('@/hooks/useRelativeTimeLabel', () => ({

--- a/src/test/pages/show-availability.client.test.tsx
+++ b/src/test/pages/show-availability.client.test.tsx
@@ -78,6 +78,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: () => ['rd-token'],
 	useAllDebridApiKey: () => 'ad-token',
 	useTorBoxAccessToken: () => 'tb-token',
+	useTorrinCreds: () => [null, null],
 }));
 
 vi.mock('@/hooks/useExternalSources', () => ({

--- a/src/test/pages/show-season.client.test.tsx
+++ b/src/test/pages/show-season.client.test.tsx
@@ -67,6 +67,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: () => ['rd-token'],
 	useAllDebridApiKey: () => 'ad-token',
 	useTorBoxAccessToken: () => 'tb-token',
+	useTorrinCreds: () => [null, null],
 }));
 
 vi.mock('@/hooks/useExternalSources', () => ({

--- a/src/test/pages/start.client.test.tsx
+++ b/src/test/pages/start.client.test.tsx
@@ -3,6 +3,7 @@ import {
 	useDebridLogin,
 	useRealDebridAccessToken,
 	useTorBoxAccessToken,
+	useTorrinCreds,
 } from '@/hooks/auth';
 import StartPage from '@/pages/start';
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -26,6 +27,7 @@ vi.mock('@/hooks/auth', () => ({
 	useRealDebridAccessToken: vi.fn(),
 	useAllDebridApiKey: vi.fn(),
 	useTorBoxAccessToken: vi.fn(),
+	useTorrinCreds: vi.fn(),
 }));
 
 describe('StartPage', () => {
@@ -57,6 +59,7 @@ describe('StartPage', () => {
 		vi.mocked(useRealDebridAccessToken).mockReturnValue([null, false, false]);
 		vi.mocked(useAllDebridApiKey).mockReturnValue(null);
 		vi.mocked(useTorBoxAccessToken).mockReturnValue(null);
+		vi.mocked(useTorrinCreds).mockReturnValue([null, null]);
 	});
 
 	it('should render the start page correctly', () => {

--- a/src/test/pages/start.client.test.tsx
+++ b/src/test/pages/start.client.test.tsx
@@ -51,6 +51,7 @@ describe('StartPage', () => {
 			loginWithRealDebrid: mockLoginWithRealDebrid,
 			loginWithAllDebrid: mockLoginWithAllDebrid,
 			loginWithTorbox: mockLoginWithTorbox,
+			loginWithTorrin: vi.fn(),
 		});
 
 		vi.mocked(useRealDebridAccessToken).mockReturnValue([null, false, false]);

--- a/src/utils/deleteTorrent.ts
+++ b/src/utils/deleteTorrent.ts
@@ -1,6 +1,7 @@
 import { deleteMagnet as deleteAdTorrent } from '@/services/allDebrid';
 import { deleteTorrent as deleteRdTorrent } from '@/services/realDebrid';
 import { deleteTorrent as deleteTbTorrent } from '@/services/torbox';
+import { deleteTorrinTorrent } from '@/services/torrin';
 import { AxiosError } from 'axios';
 import toast from 'react-hot-toast';
 import { magnetToastOptions } from './toastOptions';
@@ -84,6 +85,27 @@ export const handleDeleteTbTorrent = async (
 		);
 		const apiError = getErrorMessage(error);
 		toast.error(apiError ? `TorBox error: ${apiError}` : `Failed to delete ${id} in TorBox.`);
+		return false;
+	}
+};
+
+export const handleDeleteTrTorrent = async (
+	baseUrl: string,
+	apiKey: string,
+	id: string,
+	disableToast: boolean = false
+): Promise<boolean> => {
+	try {
+		await deleteTorrinTorrent(baseUrl, apiKey, id.substring(3));
+		if (!disableToast) toast(`Deleted ${id} from Torrin.`, magnetToastOptions);
+		return true;
+	} catch (error) {
+		console.error(
+			'Error deleting Torrin torrent:',
+			error instanceof Error ? error.message : 'Unknown error'
+		);
+		const apiError = getErrorMessage(error);
+		toast.error(apiError ? `Torrin error: ${apiError}` : `Failed to delete ${id} in Torrin.`);
 		return false;
 	}
 };

--- a/src/utils/fetchTorrents.ts
+++ b/src/utils/fetchTorrents.ts
@@ -195,6 +195,11 @@ async function processTorrents(torrentData: UserTorrentResponse[]): Promise<User
 	return results.filter((x): x is UserTorrent => x !== null);
 }
 
+export function convertToTorrinUserTorrent(torrentInfo: UserTorrentResponse): UserTorrent {
+	const rd = convertToUserTorrent(torrentInfo);
+	return { ...rd, id: `tr:${torrentInfo.id}` };
+}
+
 export const fetchAllDebrid = async (
 	adKey: string,
 	callback: (torrents: UserTorrent[]) => Promise<void>,

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -1,0 +1,96 @@
+import {
+	addTorrinMagnet,
+	deleteTorrinTorrent,
+	getTorrinTorrentInfo,
+	selectTorrinFiles,
+	unrestrictTorrinLink,
+} from '@/services/torrin';
+import ptt from 'parse-torrent-title';
+
+export const getTorrinStreamUrl = async (
+	baseUrl: string,
+	apiKey: string,
+	hash: string,
+	fileId: number,
+	mediaType: string
+): Promise<[string, string, number, number, number]> => {
+	let streamUrl = '';
+	let trLink = '';
+	let seasonNumber = -1;
+	let episodeNumber = -1;
+	let fileSize = 0;
+
+	const id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	try {
+		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
+		const torrentInfo = await getTorrinTorrentInfo(baseUrl, apiKey, id);
+
+		const fileIdx = torrentInfo.files
+			.filter((f) => f.selected)
+			.findIndex((f) => f.id === fileId);
+		const link = torrentInfo.links[fileIdx] ?? torrentInfo.links[0];
+
+		const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
+		if (!resp.streamable) {
+			throw new Error('not streamable');
+		}
+
+		streamUrl = resp.download;
+		trLink = resp.link;
+
+		if (mediaType === 'tv') {
+			const info = ptt.parse(resp.filename.split('/').pop() || '');
+			seasonNumber = info.season ?? -1;
+			episodeNumber = info.episode ?? -1;
+		}
+
+		fileSize = Math.round(resp.filesize / 1024 / 1024);
+
+		await deleteTorrinTorrent(baseUrl, apiKey, id);
+	} catch (e) {
+		console.error('error after adding hash', e);
+		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		throw e;
+	}
+
+	return [streamUrl, trLink, seasonNumber, episodeNumber, fileSize];
+};
+
+export const getBiggestFileTorrinStreamUrl = async (
+	baseUrl: string,
+	apiKey: string,
+	hash: string
+): Promise<[string, string, number]> => {
+	let streamUrl = '';
+	let trLink = '';
+	let fileSize = 0;
+
+	const id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	try {
+		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
+		const torrent = await getTorrinTorrentInfo(baseUrl, apiKey, id);
+
+		const biggestFile = torrent.files.reduce((prev, current) =>
+			prev.bytes > current.bytes ? prev : current
+		);
+		const biggestFileIdx = torrent.files.findIndex((f) => f.id === biggestFile.id);
+		const link = torrent.links[biggestFileIdx] ?? torrent.links[0];
+
+		const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
+		if (!resp.streamable) {
+			throw new Error('not streamable');
+		}
+
+		streamUrl = resp.download;
+		trLink = resp.link;
+		fileSize = Math.round(resp.filesize / 1024 / 1024);
+
+		await deleteTorrinTorrent(baseUrl, apiKey, id);
+	} catch (e) {
+		console.error('error after adding hash', e);
+		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		throw e;
+	}
+
+	return [streamUrl, trLink, fileSize];
+};

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -31,12 +31,17 @@ export const getTorrinStreamUrl = async (
 		id = await addTorrinMagnet(baseUrl, apiKey, hash);
 	}
 	try {
-		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
+		// Only (re)select files for a torrent we just added; never overwrite an
+		// existing library torrent's selection state.
+		if (addedThisCall) await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrentInfo = await getTorrinTorrentInfo(baseUrl, apiKey, id);
 
 		const selectedFiles = torrentInfo.files.filter((f) => f.selected);
 		const fileIdx = selectedFiles.findIndex((f) => f.id === fileId);
-		const link = torrentInfo.links[fileIdx] ?? torrentInfo.links[0];
+		if (fileIdx < 0) {
+			throw new Error(`requested file ${fileId} is not selected in torrent ${id}`);
+		}
+		const link = torrentInfo.links[fileIdx];
 
 		const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
 		if (!resp.streamable) {
@@ -83,7 +88,7 @@ export const getBiggestFileTorrinStreamUrl = async (
 		id = await addTorrinMagnet(baseUrl, apiKey, hash);
 	}
 	try {
-		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
+		if (addedThisCall) await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrent = await getTorrinTorrentInfo(baseUrl, apiKey, id);
 
 		if (!torrent.files || torrent.files.length === 0) {

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -42,7 +42,7 @@ export const getTorrinStreamUrl = async (
 			episodeNumber = info.episode ?? -1;
 		}
 
-		fileSize = Math.round(resp.filesize / 1024 / 1024);
+		fileSize = Math.round((torrentInfo.files[fileIdx]?.bytes ?? 0) / 1024 / 1024);
 
 		await deleteTorrinTorrent(baseUrl, apiKey, id);
 	} catch (e) {

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -1,6 +1,7 @@
 import {
 	addTorrinMagnet,
 	deleteTorrinTorrent,
+	findTorrinTorrentByHash,
 	getTorrinTorrentInfo,
 	selectTorrinFiles,
 	unrestrictTorrinLink,
@@ -20,12 +21,21 @@ export const getTorrinStreamUrl = async (
 	let episodeNumber = -1;
 	let fileSize = 0;
 
-	const id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	const existing = await findTorrinTorrentByHash(baseUrl, apiKey, hash);
+	let addedThisCall = false;
+	let id: string;
+	if (existing) {
+		id = existing.id;
+	} else {
+		addedThisCall = true;
+		id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	}
 	try {
 		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrentInfo = await getTorrinTorrentInfo(baseUrl, apiKey, id);
 
-		const fileIdx = torrentInfo.files.findIndex((f) => f.id === fileId);
+		const selectedFiles = torrentInfo.files.filter((f) => f.selected);
+		const fileIdx = selectedFiles.findIndex((f) => f.id === fileId);
 		const link = torrentInfo.links[fileIdx] ?? torrentInfo.links[0];
 
 		const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
@@ -42,12 +52,12 @@ export const getTorrinStreamUrl = async (
 			episodeNumber = info.episode ?? -1;
 		}
 
-		fileSize = Math.round((torrentInfo.files[fileIdx]?.bytes ?? 0) / 1024 / 1024);
+		fileSize = Math.round((selectedFiles[fileIdx]?.bytes ?? 0) / 1024 / 1024);
 
-		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		if (addedThisCall) await deleteTorrinTorrent(baseUrl, apiKey, id);
 	} catch (e) {
 		console.error('error after adding hash', e);
-		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		if (addedThisCall) await deleteTorrinTorrent(baseUrl, apiKey, id).catch(() => undefined);
 		throw e;
 	}
 
@@ -63,7 +73,15 @@ export const getBiggestFileTorrinStreamUrl = async (
 	let trLink = '';
 	let fileSize = 0;
 
-	const id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	const existing = await findTorrinTorrentByHash(baseUrl, apiKey, hash);
+	let addedThisCall = false;
+	let id: string;
+	if (existing) {
+		id = existing.id;
+	} else {
+		addedThisCall = true;
+		id = await addTorrinMagnet(baseUrl, apiKey, hash);
+	}
 	try {
 		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrent = await getTorrinTorrentInfo(baseUrl, apiKey, id);
@@ -86,10 +104,10 @@ export const getBiggestFileTorrinStreamUrl = async (
 		trLink = resp.link;
 		fileSize = Math.round(biggestFile.bytes / 1024 / 1024);
 
-		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		if (addedThisCall) await deleteTorrinTorrent(baseUrl, apiKey, id);
 	} catch (e) {
 		console.error('error after adding hash', e);
-		await deleteTorrinTorrent(baseUrl, apiKey, id);
+		if (addedThisCall) await deleteTorrinTorrent(baseUrl, apiKey, id).catch(() => undefined);
 		throw e;
 	}
 

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -25,9 +25,7 @@ export const getTorrinStreamUrl = async (
 		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrentInfo = await getTorrinTorrentInfo(baseUrl, apiKey, id);
 
-		const fileIdx = torrentInfo.files
-			.filter((f) => f.selected)
-			.findIndex((f) => f.id === fileId);
+		const fileIdx = torrentInfo.files.findIndex((f) => f.id === fileId);
 		const link = torrentInfo.links[fileIdx] ?? torrentInfo.links[0];
 
 		const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
@@ -70,6 +68,9 @@ export const getBiggestFileTorrinStreamUrl = async (
 		await selectTorrinFiles(baseUrl, apiKey, id, 'all');
 		const torrent = await getTorrinTorrentInfo(baseUrl, apiKey, id);
 
+		if (!torrent.files || torrent.files.length === 0) {
+			throw new Error('no files');
+		}
 		const biggestFile = torrent.files.reduce((prev, current) =>
 			prev.bytes > current.bytes ? prev : current
 		);

--- a/src/utils/getTorrinStreamUrl.ts
+++ b/src/utils/getTorrinStreamUrl.ts
@@ -84,7 +84,7 @@ export const getBiggestFileTorrinStreamUrl = async (
 
 		streamUrl = resp.download;
 		trLink = resp.link;
-		fileSize = Math.round(resp.filesize / 1024 / 1024);
+		fileSize = Math.round(biggestFile.bytes / 1024 / 1024);
 
 		await deleteTorrinTorrent(baseUrl, apiKey, id);
 	} catch (e) {

--- a/src/utils/instantChecks.ts
+++ b/src/utils/instantChecks.ts
@@ -453,7 +453,8 @@ const processTrInstantCheck = async <T extends SearchResult | EnrichedHashlistTo
 		funcs.push(async () => {
 			const resp = await torrinInstantCheck(baseUrl, apiKey, hashGroup);
 			for (const h of Object.keys(resp || {})) {
-				cached.add(h.toLowerCase());
+			for (const [h, v] of Object.entries(resp || {})) {
+				if (((v as any)?.rd?.length ?? 0) > 0) cached.add(h.toLowerCase());
 			}
 		});
 	}

--- a/src/utils/instantChecks.ts
+++ b/src/utils/instantChecks.ts
@@ -438,7 +438,7 @@ const processTbInstantCheck = async <T extends SearchResult | EnrichedHashlistTo
 	return instantCount;
 };
 
-const processTrInstantCheck = async <T extends SearchResult | EnrichedHashlistTorrent>(
+export const processTrInstantCheck = async <T extends SearchResult | EnrichedHashlistTorrent>(
 	baseUrl: string,
 	apiKey: string,
 	hashes: string[],

--- a/src/utils/instantChecks.ts
+++ b/src/utils/instantChecks.ts
@@ -1,6 +1,7 @@
 import { MagnetFile, adInstantCheck } from '@/services/allDebrid';
 import { EnrichedHashlistTorrent, FileData, SearchResult } from '@/services/mediasearch';
 import { checkCachedStatus } from '@/services/torbox';
+import { torrinInstantCheck } from '@/services/torrin';
 import { delay } from '@/utils/delay';
 import { Dispatch, SetStateAction } from 'react';
 import { toast } from 'react-hot-toast';
@@ -437,6 +438,44 @@ const processTbInstantCheck = async <T extends SearchResult | EnrichedHashlistTo
 	return instantCount;
 };
 
+const processTrInstantCheck = async <T extends SearchResult | EnrichedHashlistTorrent>(
+	baseUrl: string,
+	apiKey: string,
+	hashes: string[],
+	setTorrentList: Dispatch<SetStateAction<T[]>>,
+	sortFn?: (results: T[]) => T[]
+): Promise<number> => {
+	let instantCount = 0;
+	const cached = new Set<string>();
+	const funcs = [];
+
+	for (const hashGroup of groupBy(100, hashes)) {
+		funcs.push(async () => {
+			const resp = await torrinInstantCheck(baseUrl, apiKey, hashGroup);
+			for (const h of Object.keys(resp || {})) {
+				cached.add(h.toLowerCase());
+			}
+		});
+	}
+	await runConcurrentFunctions(funcs, 2, 200);
+
+	if (cached.size === 0) return 0;
+
+	setTorrentList((prevSearchResults) => {
+		const newSearchResults = [...prevSearchResults];
+		for (const torrent of newSearchResults) {
+			if (torrent.noVideos) continue;
+			if (cached.has(torrent.hash.toLowerCase())) {
+				torrent.torrinAvailable = true;
+				instantCount += 1;
+			}
+		}
+		return sortFn ? sortFn(newSearchResults) : newSearchResults;
+	});
+
+	return instantCount;
+};
+
 // Wrapper functions
 export const wrapLoading = async function (debrid: string, checkAvailability: Promise<number>) {
 	return await toast.promise(
@@ -495,3 +534,10 @@ export const checkDatabaseAvailabilityTb2 = (
 	hashes: string[],
 	setTorrentList: Dispatch<SetStateAction<EnrichedHashlistTorrent[]>>
 ) => processTbInstantCheck(tbKey, hashes, setTorrentList);
+
+export const checkDatabaseAvailabilityTr2 = (
+	baseUrl: string,
+	apiKey: string,
+	hashes: string[],
+	setTorrentList: Dispatch<SetStateAction<EnrichedHashlistTorrent[]>>
+) => processTrInstantCheck(baseUrl, apiKey, hashes, setTorrentList);

--- a/src/utils/instantChecks.ts
+++ b/src/utils/instantChecks.ts
@@ -452,7 +452,6 @@ const processTrInstantCheck = async <T extends SearchResult | EnrichedHashlistTo
 	for (const hashGroup of groupBy(100, hashes)) {
 		funcs.push(async () => {
 			const resp = await torrinInstantCheck(baseUrl, apiKey, hashGroup);
-			for (const h of Object.keys(resp || {})) {
 			for (const [h, v] of Object.entries(resp || {})) {
 				if (((v as any)?.rd?.length ?? 0) > 0) cached.add(h.toLowerCase());
 			}

--- a/src/utils/libraryFilters.ts
+++ b/src/utils/libraryFilters.ts
@@ -122,6 +122,7 @@ export const filterLibraryItems = ({
 			rd: 'Real-Debrid',
 			ad: 'AllDebrid',
 			tb: 'TorBox',
+			tr: 'Torrin',
 		};
 		nextHelpText = `Showing torrents from ${serviceNames[serviceValue] ?? serviceValue}`;
 	}

--- a/src/utils/results.tsx
+++ b/src/utils/results.tsx
@@ -18,6 +18,8 @@ export const torrentPrefix = (id: string) =>
 		<span className="bg-[#b5d496] text-xs text-black">RD</span>
 	) : id.startsWith('tb:') ? (
 		<span className="bg-[#4f46e5] text-xs text-white">TB</span>
+	) : id.startsWith('tr:') ? (
+		<span className="bg-[#0ea5e9] text-xs text-white">TR</span>
 	) : (
 		<span className="bg-[#fbc730] text-[8px] text-black">AD</span>
 	);

--- a/src/utils/streamMetadata.ts
+++ b/src/utils/streamMetadata.ts
@@ -238,7 +238,7 @@ export function formatStremioStreamTitle(
 	size: number,
 	metadata: StreamMetadata | null,
 	isUserCast: boolean,
-	provider: 'RD' | 'TB' | 'AD' = 'RD'
+	provider: 'RD' | 'TB' | 'AD' | 'TR' = 'RD'
 ): string {
 	let displayFilename = decodeURIComponent(filename);
 	if (displayFilename.length > 60) {

--- a/src/utils/torrinCastApiClient.test.ts
+++ b/src/utils/torrinCastApiClient.test.ts
@@ -1,0 +1,203 @@
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios');
+vi.mock('react-hot-toast');
+vi.mock('./batch', () => ({
+	runConcurrentFunctions: vi.fn(async (fns: (() => Promise<any>)[]) => {
+		const results = [];
+		for (const fn of fns) {
+			results.push(await fn());
+		}
+		return [results];
+	}),
+}));
+vi.mock('./groupBy', () => ({
+	groupBy: vi.fn((size: number, arr: any[]) => {
+		const result: any[][] = [];
+		for (let i = 0; i < arr.length; i += size) {
+			result.push(arr.slice(i, i + size));
+		}
+		return result;
+	}),
+}));
+
+import {
+	deleteTorrinCastedLink,
+	fetchTorrinCastedLinks,
+	handleCastMovieTorrin,
+	handleCastTvShowTorrin,
+	saveTorrinCastProfile,
+	updateTorrinSizeLimits,
+} from './torrinCastApiClient';
+
+const BASE = 'https://tr.test';
+const KEY = 'key';
+const creds = `baseUrl=${encodeURIComponent(BASE)}&apiKey=${encodeURIComponent(KEY)}`;
+
+describe('torrinCastApiClient', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('handleCastMovieTorrin', () => {
+		it('casts a movie and shows a success toast', async () => {
+			vi.mocked(axios.get).mockResolvedValue({ data: { filename: 'Movie.mkv' } });
+
+			await handleCastMovieTorrin('tt123', BASE, KEY, 'hash');
+
+			expect(axios.get).toHaveBeenCalledWith(
+				`/api/stremio-tr/cast/movie/tt123?${creds}&hash=hash`
+			);
+			expect(toast).toHaveBeenCalledWith(
+				'Casted Movie.mkv to Stremio (Torrin).',
+				expect.any(Object)
+			);
+		});
+
+		it('surfaces the server error message', async () => {
+			vi.mocked(axios.get).mockRejectedValue({
+				response: { data: { errorMessage: 'Server error' } },
+			});
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			await handleCastMovieTorrin('tt123', BASE, KEY, 'hash');
+
+			expect(toast.error).toHaveBeenCalledWith('Server error', expect.any(Object));
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('handleCastTvShowTorrin', () => {
+		it('casts episodes and shows a success toast', async () => {
+			vi.mocked(axios.get).mockResolvedValue({ data: { errorEpisodes: [] } });
+
+			await handleCastTvShowTorrin('tt123', BASE, KEY, 'hash', ['1', '2']);
+
+			expect(toast.success).toHaveBeenCalledWith(
+				'Finished casting all episodes to Stremio (Torrin).',
+				expect.any(Object)
+			);
+		});
+
+		it('builds the URL with fileIds params', async () => {
+			vi.mocked(axios.get).mockResolvedValue({ data: { errorEpisodes: [] } });
+
+			await handleCastTvShowTorrin('tt123', BASE, KEY, 'hash', ['10', '20']);
+
+			expect(axios.get).toHaveBeenCalledWith(
+				`/api/stremio-tr/cast/series/tt123?${creds}&hash=hash&fileIds=10&fileIds=20`
+			);
+		});
+
+		it('reports failed episodes', async () => {
+			vi.mocked(axios.get).mockResolvedValue({ data: { errorEpisodes: ['S01E01'] } });
+
+			await handleCastTvShowTorrin('tt123', BASE, KEY, 'hash', ['1']);
+
+			expect(toast.error).toHaveBeenCalledWith(
+				expect.stringContaining('Cast failed for S01E01'),
+				expect.any(Object)
+			);
+		});
+	});
+
+	describe('saveTorrinCastProfile', () => {
+		it('posts profile data with baseUrl + apiKey', async () => {
+			vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+			await saveTorrinCastProfile(BASE, KEY, 5000, 2000, 3, false);
+
+			expect(axios.post).toHaveBeenCalledWith('/api/stremio-tr/cast/saveProfile', {
+				baseUrl: BASE,
+				apiKey: KEY,
+				movieMaxSize: 5000,
+				episodeMaxSize: 2000,
+				otherStreamsLimit: 3,
+				hideCastOption: false,
+			});
+		});
+
+		it('omits undefined optional fields', async () => {
+			vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+			await saveTorrinCastProfile(BASE, KEY);
+
+			expect(axios.post).toHaveBeenCalledWith('/api/stremio-tr/cast/saveProfile', {
+				baseUrl: BASE,
+				apiKey: KEY,
+			});
+		});
+
+		it('silently handles errors', async () => {
+			vi.mocked(axios.post).mockRejectedValue(new Error('fail'));
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			await expect(saveTorrinCastProfile(BASE, KEY)).resolves.not.toThrow();
+
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('updateTorrinSizeLimits', () => {
+		it('posts size-limit data', async () => {
+			vi.mocked(axios.post).mockResolvedValue({ data: {} });
+
+			await updateTorrinSizeLimits(BASE, KEY, 3000, 1000, 5, true);
+
+			expect(axios.post).toHaveBeenCalledWith('/api/stremio-tr/cast/updateSizeLimits', {
+				baseUrl: BASE,
+				apiKey: KEY,
+				movieMaxSize: 3000,
+				episodeMaxSize: 1000,
+				otherStreamsLimit: 5,
+				hideCastOption: true,
+			});
+		});
+	});
+
+	describe('fetchTorrinCastedLinks', () => {
+		it('returns the links array', async () => {
+			vi.mocked(axios.get).mockResolvedValue({ data: { links: [{ id: 1 }] } });
+
+			const result = await fetchTorrinCastedLinks(BASE, KEY);
+
+			expect(axios.get).toHaveBeenCalledWith(`/api/stremio-tr/links?${creds}`);
+			expect(result).toEqual([{ id: 1 }]);
+		});
+
+		it('returns an empty array on error', async () => {
+			vi.mocked(axios.get).mockRejectedValue(new Error('fail'));
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			const result = await fetchTorrinCastedLinks(BASE, KEY);
+
+			expect(result).toEqual([]);
+			consoleSpy.mockRestore();
+		});
+	});
+
+	describe('deleteTorrinCastedLink', () => {
+		it('returns true on success', async () => {
+			vi.mocked(axios.delete).mockResolvedValue({ data: {} });
+
+			const result = await deleteTorrinCastedLink(BASE, KEY, 'tt123', 'hash');
+
+			expect(axios.delete).toHaveBeenCalledWith('/api/stremio-tr/deletelink', {
+				data: { baseUrl: BASE, apiKey: KEY, imdbId: 'tt123', hash: 'hash' },
+			});
+			expect(result).toBe(true);
+		});
+
+		it('returns false on error', async () => {
+			vi.mocked(axios.delete).mockRejectedValue(new Error('fail'));
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			const result = await deleteTorrinCastedLink(BASE, KEY, 'tt123', 'hash');
+
+			expect(result).toBe(false);
+			consoleSpy.mockRestore();
+		});
+	});
+});

--- a/src/utils/torrinCastApiClient.ts
+++ b/src/utils/torrinCastApiClient.ts
@@ -1,0 +1,140 @@
+import axios from 'axios';
+import toast from 'react-hot-toast';
+import { runConcurrentFunctions } from './batch';
+import { groupBy } from './groupBy';
+import { castToastOptions } from './toastOptions';
+
+const creds = (baseUrl: string, apiKey: string) =>
+	`baseUrl=${encodeURIComponent(baseUrl)}&apiKey=${encodeURIComponent(apiKey)}`;
+
+export const handleCastMovieTorrin = async (
+	imdbId: string,
+	baseUrl: string,
+	apiKey: string,
+	hash: string
+) => {
+	try {
+		const resp = await axios.get(
+			`/api/stremio-tr/cast/movie/${imdbId}?${creds(baseUrl, apiKey)}&hash=${hash}`
+		);
+		toast(`Casted ${resp.data.filename} to Stremio (Torrin).`, castToastOptions);
+	} catch (error: any) {
+		const errorMessage =
+			error?.response?.data?.errorMessage ||
+			(error instanceof Error ? error.message : 'Unknown error');
+		console.error('Error casting movie (Torrin):', errorMessage);
+		toast.error(errorMessage, castToastOptions);
+	}
+};
+
+export const handleCastTvShowTorrin = async (
+	imdbId: string,
+	baseUrl: string,
+	apiKey: string,
+	hash: string,
+	fileIds: string[]
+) => {
+	const yetToCast = groupBy(5, fileIds).map((batch) => async () => {
+		try {
+			const fIdParam = batch.map((id) => `fileIds=${id}`).join('&');
+			const resp = await axios.get(
+				`/api/stremio-tr/cast/series/${imdbId}?${creds(baseUrl, apiKey)}&hash=${hash}&${fIdParam}`
+			);
+			const errorEpisodes = resp.data.errorEpisodes;
+			if (errorEpisodes.length) {
+				toast.error(
+					`Cast failed for ${errorEpisodes[0]}${
+						errorEpisodes.length > 1 ? ` and ${errorEpisodes.length - 1} more` : ''
+					} (Torrin).`,
+					castToastOptions
+				);
+			} else {
+				toast.success(
+					`Casted ${batch.length} episode${batch.length === 1 ? '' : 's'} to Stremio (Torrin).`,
+					castToastOptions
+				);
+			}
+		} catch (error) {
+			toast.error(
+				`Failed to cast ${batch.length} episode${batch.length === 1 ? '' : 's'} (Torrin).`,
+				castToastOptions
+			);
+		}
+	});
+
+	const [results] = await runConcurrentFunctions(yetToCast, 4, 0);
+	if (results.length) {
+		toast.success(`Finished casting all episodes to Stremio (Torrin).`, castToastOptions);
+	}
+};
+
+export const saveTorrinCastProfile = async (
+	baseUrl: string,
+	apiKey: string,
+	movieMaxSize?: number,
+	episodeMaxSize?: number,
+	otherStreamsLimit?: number,
+	hideCastOption?: boolean
+) => {
+	try {
+		await axios.post(`/api/stremio-tr/cast/saveProfile`, {
+			baseUrl,
+			apiKey,
+			...(movieMaxSize !== undefined && { movieMaxSize }),
+			...(episodeMaxSize !== undefined && { episodeMaxSize }),
+			...(otherStreamsLimit !== undefined && { otherStreamsLimit }),
+			...(hideCastOption !== undefined && { hideCastOption }),
+		});
+	} catch (error) {
+		console.error('Error saving Torrin cast profile:', error);
+	}
+};
+
+export const updateTorrinSizeLimits = async (
+	baseUrl: string,
+	apiKey: string,
+	movieMaxSize?: number,
+	episodeMaxSize?: number,
+	otherStreamsLimit?: number,
+	hideCastOption?: boolean
+) => {
+	try {
+		await axios.post(`/api/stremio-tr/cast/updateSizeLimits`, {
+			baseUrl,
+			apiKey,
+			movieMaxSize,
+			episodeMaxSize,
+			otherStreamsLimit,
+			hideCastOption,
+		});
+	} catch (error) {
+		console.error('Error updating Torrin size limits:', error);
+	}
+};
+
+export const fetchTorrinCastedLinks = async (baseUrl: string, apiKey: string) => {
+	try {
+		const resp = await axios.get(`/api/stremio-tr/links?${creds(baseUrl, apiKey)}`);
+		return resp.data.links || [];
+	} catch (error) {
+		console.error('Error fetching Torrin casted links:', error);
+		return [];
+	}
+};
+
+export const deleteTorrinCastedLink = async (
+	baseUrl: string,
+	apiKey: string,
+	imdbId: string,
+	hash: string
+): Promise<boolean> => {
+	try {
+		await axios.delete(`/api/stremio-tr/deletelink`, {
+			data: { baseUrl, apiKey, imdbId, hash },
+		});
+		return true;
+	} catch (error) {
+		console.error('Error deleting Torrin casted link:', error);
+		return false;
+	}
+};

--- a/src/utils/torrinCastApiClient.ts
+++ b/src/utils/torrinCastApiClient.ts
@@ -40,7 +40,7 @@ export const handleCastTvShowTorrin = async (
 			const resp = await axios.get(
 				`/api/stremio-tr/cast/series/${imdbId}?${creds(baseUrl, apiKey)}&hash=${hash}&${fIdParam}`
 			);
-			const errorEpisodes = resp.data.errorEpisodes;
+			const errorEpisodes = resp.data.errorEpisodes ?? [];
 			if (errorEpisodes.length) {
 				toast.error(
 					`Cast failed for ${errorEpisodes[0]}${
@@ -55,6 +55,7 @@ export const handleCastTvShowTorrin = async (
 				);
 			}
 		} catch (error) {
+			console.error('Error casting episodes (Torrin):', error);
 			toast.error(
 				`Failed to cast ${batch.length} episode${batch.length === 1 ? '' : 's'} (Torrin).`,
 				castToastOptions

--- a/src/utils/torrinCastApiHelpers.test.ts
+++ b/src/utils/torrinCastApiHelpers.test.ts
@@ -1,0 +1,170 @@
+import { createMockRequest, createMockResponse } from '@/test/utils/api';
+import crypto from 'crypto';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/torrin', () => ({
+	getTorrinUser: vi.fn(),
+}));
+
+import { getTorrinUser } from '@/services/torrin';
+import {
+	generateTorrinUserId,
+	handleApiError,
+	validateMethod,
+	validateTorrinApiKey,
+	validateTorrinCreds,
+} from './torrinCastApiHelpers';
+
+const originalSalt = process.env.DMMCAST_SALT;
+const testSalt = 'test-tr-salt';
+
+describe('torrinCastApiHelpers', () => {
+	beforeEach(() => {
+		process.env.DMMCAST_SALT = testSalt;
+		vi.mocked(getTorrinUser).mockReset();
+	});
+
+	afterAll(() => {
+		process.env.DMMCAST_SALT = originalSalt;
+	});
+
+	describe('validateMethod', () => {
+		it('returns true for allowed method', () => {
+			const req = createMockRequest({ method: 'POST' });
+			const res = createMockResponse();
+			expect(validateMethod(req, res, ['POST'])).toBe(true);
+		});
+
+		it('returns false and sets 405 for disallowed method', () => {
+			const req = createMockRequest({ method: 'PATCH' });
+			const res = createMockResponse();
+			expect(validateMethod(req, res, ['GET'])).toBe(false);
+			expect(res._getStatusCode()).toBe(405);
+		});
+	});
+
+	describe('validateTorrinCreds', () => {
+		it('returns creds from query', () => {
+			const req = createMockRequest({
+				query: { baseUrl: 'https://tr.test', apiKey: 'tr-key' },
+			});
+			const res = createMockResponse();
+			expect(validateTorrinCreds(req, res)).toEqual({
+				baseUrl: 'https://tr.test',
+				apiKey: 'tr-key',
+			});
+		});
+
+		it('returns creds from body', () => {
+			const req = createMockRequest({
+				body: { baseUrl: 'https://tr.test', apiKey: 'body-key' },
+			});
+			const res = createMockResponse();
+			expect(validateTorrinCreds(req, res)).toEqual({
+				baseUrl: 'https://tr.test',
+				apiKey: 'body-key',
+			});
+		});
+
+		it('returns null and sets 401 when baseUrl is missing', () => {
+			const req = createMockRequest({ query: { apiKey: 'tr-key' } });
+			const res = createMockResponse();
+			expect(validateTorrinCreds(req, res)).toBeNull();
+			expect(res._getStatusCode()).toBe(401);
+		});
+
+		it('returns null and sets 401 when apiKey is missing', () => {
+			const req = createMockRequest({ query: { baseUrl: 'https://tr.test' } });
+			const res = createMockResponse();
+			expect(validateTorrinCreds(req, res)).toBeNull();
+			expect(res._getStatusCode()).toBe(401);
+		});
+	});
+
+	describe('generateTorrinUserId', () => {
+		it('generates a deterministic id namespaced by instance + identity', async () => {
+			vi.mocked(getTorrinUser).mockResolvedValue({
+				email: 'user@example.com',
+			} as any);
+
+			const result = await generateTorrinUserId('https://tr.test/', 'tr-key');
+
+			expect(getTorrinUser).toHaveBeenCalledWith('https://tr.test/', 'tr-key');
+			const expected = crypto
+				.createHmac('sha256', testSalt)
+				.update('torrin:https://tr.test:user@example.com')
+				.digest('base64url')
+				.slice(0, 12);
+			expect(result).toBe(expected);
+		});
+
+		it('falls back to username then id for identity', async () => {
+			vi.mocked(getTorrinUser).mockResolvedValue({ username: 'bob' } as any);
+			const result = await generateTorrinUserId('https://tr.test', 'tr-key');
+			const expected = crypto
+				.createHmac('sha256', testSalt)
+				.update('torrin:https://tr.test:bob')
+				.digest('base64url')
+				.slice(0, 12);
+			expect(result).toBe(expected);
+		});
+
+		it('throws when DMMCAST_SALT is missing', async () => {
+			delete process.env.DMMCAST_SALT;
+			vi.mocked(getTorrinUser).mockResolvedValue({ email: 'user@example.com' } as any);
+			await expect(generateTorrinUserId('https://tr.test', 'key')).rejects.toThrow(
+				'Failed to generate Torrin user ID'
+			);
+		});
+
+		it('throws when getTorrinUser rejects', async () => {
+			vi.mocked(getTorrinUser).mockRejectedValue(new Error('API error'));
+			await expect(generateTorrinUserId('https://tr.test', 'key')).rejects.toThrow(
+				'Failed to generate Torrin user ID'
+			);
+		});
+	});
+
+	describe('validateTorrinApiKey', () => {
+		it('returns valid with email for valid creds', async () => {
+			vi.mocked(getTorrinUser).mockResolvedValue({ email: 'user@tr.com' } as any);
+			const result = await validateTorrinApiKey('https://tr.test', 'valid-key');
+			expect(result).toEqual({ valid: true, email: 'user@tr.com' });
+		});
+
+		it('returns invalid when identity is missing', async () => {
+			vi.mocked(getTorrinUser).mockResolvedValue({} as any);
+			const result = await validateTorrinApiKey('https://tr.test', 'bad-key');
+			expect(result).toEqual({ valid: false });
+		});
+
+		it('returns invalid on error', async () => {
+			vi.mocked(getTorrinUser).mockRejectedValue(new Error('fail'));
+			const result = await validateTorrinApiKey('https://tr.test', 'bad-key');
+			expect(result).toEqual({ valid: false });
+		});
+	});
+
+	describe('handleApiError', () => {
+		it('sends 500 with default message', () => {
+			const res = createMockResponse();
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			handleApiError(new Error('boom'), res);
+
+			expect(res._getStatusCode()).toBe(500);
+			expect(res._getData()).toEqual({ error: 'Internal Server Error: boom' });
+			consoleSpy.mockRestore();
+		});
+
+		it('sends 500 with custom message', () => {
+			const res = createMockResponse();
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+			handleApiError('err', res, 'Custom Torrin error');
+
+			expect(res._getData()).toEqual({ error: 'Custom Torrin error' });
+			consoleSpy.mockRestore();
+		});
+	});
+});

--- a/src/utils/torrinCastApiHelpers.ts
+++ b/src/utils/torrinCastApiHelpers.ts
@@ -1,0 +1,77 @@
+import { getTorrinUser } from '@/services/torrin';
+import crypto from 'crypto';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export const validateMethod = (
+	req: NextApiRequest,
+	res: NextApiResponse,
+	allowedMethods: string[]
+): boolean => {
+	if (!allowedMethods.includes(req.method || '')) {
+		res.setHeader('Allow', allowedMethods);
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+		return false;
+	}
+	return true;
+};
+
+export const validateTorrinCreds = (
+	req: NextApiRequest,
+	res: NextApiResponse
+): { baseUrl: string; apiKey: string } | null => {
+	const apiKey = req.query.apiKey || req.body?.apiKey;
+	const baseUrl = req.query.baseUrl || req.body?.baseUrl;
+	if (!apiKey || typeof apiKey !== 'string' || !baseUrl || typeof baseUrl !== 'string') {
+		res.status(401).json({ error: 'Invalid or missing Torrin baseUrl/apiKey' });
+		return null;
+	}
+	return { baseUrl, apiKey };
+};
+
+export const generateTorrinUserId = async (baseUrl: string, apiKey: string): Promise<string> => {
+	try {
+		const user = await getTorrinUser(baseUrl, apiKey);
+		const identity = user.email || user.username || (user.id != null ? String(user.id) : '');
+		if (!identity) {
+			throw new Error('Torrin user identity not available');
+		}
+
+		const salt = process.env.DMMCAST_SALT;
+		if (!salt) {
+			throw new Error('DMMCAST_SALT environment variable is not set');
+		}
+
+		const normalizedBase = baseUrl.replace(/\/+$/, '');
+		const hmac = crypto
+			.createHmac('sha256', salt)
+			.update(`torrin:${normalizedBase}:${identity}`)
+			.digest('base64url');
+
+		return hmac.slice(0, 12);
+	} catch (error) {
+		throw new Error('Failed to generate Torrin user ID');
+	}
+};
+
+export const validateTorrinApiKey = async (
+	baseUrl: string,
+	apiKey: string
+): Promise<{ valid: boolean; email?: string }> => {
+	try {
+		const user = await getTorrinUser(baseUrl, apiKey);
+		const identity = user.email || user.username || (user.id != null ? String(user.id) : '');
+		if (identity) {
+			return { valid: true, email: user.email };
+		}
+		return { valid: false };
+	} catch {
+		return { valid: false };
+	}
+};
+
+export const handleApiError = (error: any, res: NextApiResponse, customMessage?: string) => {
+	console.error(customMessage || 'Torrin API Error:', error);
+	res.status(500).json({
+		error: customMessage || `Internal Server Error: ${error.message || error}`,
+	});
+};

--- a/src/utils/torrinCastCatalogHelper.test.ts
+++ b/src/utils/torrinCastCatalogHelper.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/repository', () => ({
+	repository: {
+		getTorrinCastProfile: vi.fn(),
+	},
+}));
+
+vi.mock('@/services/torrin', () => ({
+	getTorrinTorrentsList: vi.fn(),
+	getTorrinTorrentInfo: vi.fn(),
+}));
+
+import { repository as db } from '@/services/repository';
+import { getTorrinTorrentInfo, getTorrinTorrentsList } from '@/services/torrin';
+import { PAGE_SIZE, getTorrinDMMLibrary, getTorrinDMMTorrent } from './torrinCastCatalogHelper';
+
+const profile = { baseUrl: 'https://tr.test', apiKey: 'key' };
+
+describe('torrinCastCatalogHelper', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		process.env.DMM_ORIGIN = 'https://debridmediamanager.com';
+	});
+
+	describe('PAGE_SIZE', () => {
+		it('is 12', () => {
+			expect(PAGE_SIZE).toBe(12);
+		});
+	});
+
+	describe('getTorrinDMMLibrary', () => {
+		it('returns 401 when no profile found', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(null);
+			const result = await getTorrinDMMLibrary('user1', 1);
+			expect(result).toEqual({
+				error: 'Go to DMM and connect your Torrin instance',
+				status: 401,
+			});
+		});
+
+		it('returns 401 when profile lookup throws', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockRejectedValue(new Error('DB error'));
+			const result = await getTorrinDMMLibrary('user1', 1);
+			expect(result.status).toBe(401);
+		});
+
+		it('returns metas mapped from the torrent list', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentsList).mockResolvedValue({
+				data: [
+					{ id: 'a1', filename: 'Movie A' },
+					{ id: 'b2', filename: 'Movie B' },
+				],
+				totalCount: 2,
+			} as any);
+
+			const result = await getTorrinDMMLibrary('user1', 1);
+
+			expect(result.status).toBe(200);
+			expect(result.data!.metas).toEqual([
+				{ id: 'dmm-tr:a1', name: 'Movie A', type: 'other' },
+				{ id: 'dmm-tr:b2', name: 'Movie B', type: 'other' },
+			]);
+		});
+
+		it('sets hasMore true when a full page is returned', async () => {
+			const data = Array.from({ length: PAGE_SIZE }, (_, i) => ({
+				id: `t${i}`,
+				filename: `T${i}`,
+			}));
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentsList).mockResolvedValue({ data, totalCount: 100 } as any);
+
+			const result = await getTorrinDMMLibrary('user1', 1);
+			expect(result.data!.hasMore).toBe(true);
+		});
+
+		it('sets hasMore false for a partial page', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentsList).mockResolvedValue({
+				data: [{ id: 'x', filename: 'Only' }],
+				totalCount: 1,
+			} as any);
+
+			const result = await getTorrinDMMLibrary('user1', 1);
+			expect(result.data!.hasMore).toBe(false);
+		});
+
+		it('passes page + page size to the list call', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentsList).mockResolvedValue({ data: [], totalCount: 0 } as any);
+
+			await getTorrinDMMLibrary('user1', 3);
+			expect(getTorrinTorrentsList).toHaveBeenCalledWith(
+				'https://tr.test',
+				'key',
+				PAGE_SIZE,
+				3
+			);
+		});
+	});
+
+	describe('getTorrinDMMTorrent', () => {
+		it('returns 401 when no profile found', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(null);
+			const result = await getTorrinDMMTorrent('user1', 'abc');
+			expect(result.status).toBe(401);
+		});
+
+		it('returns torrent meta with selected files as videos', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentInfo).mockResolvedValue({
+				id: 'abc',
+				filename: 'Test Torrent',
+				files: [
+					{ id: 1, path: 'a/file1.mkv', bytes: 1073741824, selected: 1 },
+					{ id: 2, path: 'b/file2.mp4', bytes: 2147483648, selected: 1 },
+				],
+				links: ['https://tr/l1', 'https://tr/l2'],
+			} as any);
+
+			const result = await getTorrinDMMTorrent('user1', 'abc');
+
+			expect(result.status).toBe(200);
+			expect(result.data!.meta.id).toBe('dmm-tr:abc');
+			expect(result.data!.meta.type).toBe('other');
+			expect(result.data!.meta.videos).toHaveLength(2);
+			expect(result.data!.meta.videos[0].streams[0].url).toContain(
+				'/api/stremio-tr/user1/play/'
+			);
+		});
+
+		it('skips files without a matching link', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentInfo).mockResolvedValue({
+				id: 'abc',
+				filename: 'Partial',
+				files: [
+					{ id: 1, path: 'file1.mkv', bytes: 100, selected: 1 },
+					{ id: 2, path: 'file2.mkv', bytes: 100, selected: 1 },
+				],
+				links: ['https://tr/l1'],
+			} as any);
+
+			const result = await getTorrinDMMTorrent('user1', 'abc');
+			expect(result.data!.meta.videos).toHaveLength(1);
+		});
+
+		it('sorts videos by title', async () => {
+			vi.mocked(db.getTorrinCastProfile).mockResolvedValue(profile as any);
+			vi.mocked(getTorrinTorrentInfo).mockResolvedValue({
+				id: 'abc',
+				filename: 'Show',
+				files: [
+					{ id: 2, path: 'z-file.mkv', bytes: 100, selected: 1 },
+					{ id: 1, path: 'a-file.mkv', bytes: 100, selected: 1 },
+				],
+				links: ['https://tr/l1', 'https://tr/l2'],
+			} as any);
+
+			const result = await getTorrinDMMTorrent('user1', 'abc');
+			const titles = result.data!.meta.videos.map((v: any) => v.title);
+			expect(titles[0]).toMatch(/^a-file/);
+			expect(titles[1]).toMatch(/^z-file/);
+		});
+	});
+});

--- a/src/utils/torrinCastCatalogHelper.ts
+++ b/src/utils/torrinCastCatalogHelper.ts
@@ -14,9 +14,17 @@ export async function getTorrinDMMLibrary(userid: string, page: number) {
 		return { error: 'Go to DMM and connect your Torrin instance', status: 401 };
 	}
 
-	const results = await getTorrinTorrentsList(profile.baseUrl, profile.apiKey, PAGE_SIZE, page);
+	let results;
+	try {
+		results = await getTorrinTorrentsList(profile.baseUrl, profile.apiKey, PAGE_SIZE, page);
+	} catch (error) {
+		return { error: 'Failed to fetch library from Torrin', status: 502 };
+	}
 	const torrents = results.data;
-	const hasMore = torrents.length === PAGE_SIZE;
+	const hasMore =
+		results.totalCount != null
+			? page * PAGE_SIZE < results.totalCount
+			: torrents.length === PAGE_SIZE;
 
 	return {
 		data: {
@@ -43,7 +51,12 @@ export async function getTorrinDMMTorrent(userid: string, torrentID: string) {
 		return { error: 'Go to DMM and connect your Torrin instance', status: 401 };
 	}
 
-	const torrent = await getTorrinTorrentInfo(profile.baseUrl, profile.apiKey, torrentID);
+	let torrent;
+	try {
+		torrent = await getTorrinTorrentInfo(profile.baseUrl, profile.apiKey, torrentID);
+	} catch (error) {
+		return { error: 'Failed to fetch torrent from Torrin', status: 502 };
+	}
 	if (!torrent) {
 		return { error: 'Torrent not found', status: 404 };
 	}

--- a/src/utils/torrinCastCatalogHelper.ts
+++ b/src/utils/torrinCastCatalogHelper.ts
@@ -1,0 +1,87 @@
+import { repository as db } from '@/services/repository';
+import { getTorrinTorrentInfo, getTorrinTorrentsList } from '@/services/torrin';
+
+export const PAGE_SIZE = 12;
+
+export async function getTorrinDMMLibrary(userid: string, page: number) {
+	let profile: { baseUrl: string; apiKey: string } | null = null;
+	try {
+		profile = await db.getTorrinCastProfile(userid);
+		if (!profile) {
+			throw new Error(`no profile found for user ${userid}`);
+		}
+	} catch (error) {
+		return { error: 'Go to DMM and connect your Torrin instance', status: 401 };
+	}
+
+	const results = await getTorrinTorrentsList(profile.baseUrl, profile.apiKey, PAGE_SIZE, page);
+	const torrents = results.data;
+	const hasMore = torrents.length === PAGE_SIZE;
+
+	return {
+		data: {
+			metas: torrents.map((torrent) => ({
+				id: `dmm-tr:${torrent.id}`,
+				name: torrent.filename,
+				type: 'other',
+			})),
+			hasMore,
+			cacheMaxAge: 0,
+		},
+		status: 200,
+	};
+}
+
+export async function getTorrinDMMTorrent(userid: string, torrentID: string) {
+	let profile: { baseUrl: string; apiKey: string } | null = null;
+	try {
+		profile = await db.getTorrinCastProfile(userid);
+		if (!profile) {
+			throw new Error(`no profile found for user ${userid}`);
+		}
+	} catch (error) {
+		return { error: 'Go to DMM and connect your Torrin instance', status: 401 };
+	}
+
+	const torrent = await getTorrinTorrentInfo(profile.baseUrl, profile.apiKey, torrentID);
+	if (!torrent) {
+		return { error: 'Torrent not found', status: 404 };
+	}
+
+	const selectedFiles = torrent.files.filter((f) => f.selected);
+	const videos = selectedFiles
+		.map((file, idx) => {
+			const link = torrent.links[idx];
+			if (!link) return null;
+			return {
+				id: `dmm-tr:${torrentID}:${file.id}`,
+				title: `${file.path.split('/').pop()} - ${((file.bytes || 0) / 1024 / 1024 / 1024).toFixed(2)} GB`,
+				streams: [
+					{
+						url: `${process.env.DMM_ORIGIN}/api/stremio-tr/${userid}/play/${encodeURIComponent(link)}`,
+						behaviorHints: {
+							bingeGroup: `dmm-tr:${torrentID}`,
+						},
+					},
+				],
+			};
+		})
+		.filter((v): v is NonNullable<typeof v> => v !== null);
+
+	videos.sort((a, b) => a.title.localeCompare(b.title));
+
+	const totalSize = torrent.files.reduce((sum, f) => sum + (f.bytes || 0), 0);
+
+	return {
+		data: {
+			meta: {
+				id: `dmm-tr:${torrentID}`,
+				type: 'other',
+				name: `DMM TR: ${torrent.filename} - ${(totalSize / 1024 / 1024 / 1024).toFixed(2)} GB`,
+				videos,
+			},
+			cacheMaxAge: 0,
+		},
+		status: 200,
+	};
+}

--- a/src/utils/torrinInfo.test.ts
+++ b/src/utils/torrinInfo.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserTorrentStatus, type UserTorrent } from '@/torrent/userTorrent';
+import type { Dispatch, SetStateAction } from 'react';
+
+const modalMock = vi.hoisted(() => ({
+	fire: vi.fn(),
+	close: vi.fn(),
+	showLoading: vi.fn(),
+}));
+const toastMock = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('@/components/modals/modal', () => ({ default: modalMock }));
+vi.mock('react-hot-toast', () => ({ default: toastMock }));
+vi.mock('@/services/torrin', () => ({
+	getTorrinTorrentInfo: vi.fn(),
+	unrestrictTorrinLink: vi.fn(),
+}));
+vi.mock('./deleteTorrent', () => ({ handleDeleteTrTorrent: vi.fn() }));
+
+import { getTorrinTorrentInfo } from '@/services/torrin';
+import { handleShowInfoForTorrin } from './torrinInfo';
+
+const torrent: UserTorrent = {
+	id: 'tr:abc123',
+	filename: 'Sample.mkv',
+	title: 'Sample',
+	hash: 'abc',
+	bytes: 123,
+	progress: 100,
+	status: UserTorrentStatus.finished,
+	serviceStatus: 'downloaded',
+	added: new Date('2023-01-01T00:00:00Z'),
+	mediaType: 'movie',
+	info: {} as any,
+	links: [],
+	selectedFiles: [],
+	seeders: 0,
+	speed: 0,
+};
+
+const setList = vi.fn() as unknown as (fn: (prev: UserTorrent[]) => UserTorrent[]) => void;
+const setSelected = vi.fn() as unknown as Dispatch<SetStateAction<Set<string>>>;
+const torrentDB = { deleteById: vi.fn() } as any;
+
+describe('handleShowInfoForTorrin', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		modalMock.fire.mockResolvedValue({});
+	});
+
+	it('fetches info by the un-prefixed id and opens a modal with the file list', async () => {
+		vi.mocked(getTorrinTorrentInfo).mockResolvedValue({
+			id: 'abc123',
+			filename: 'Sample.Movie.2024.mkv',
+			status: 'downloaded',
+			bytes: 2147483648,
+			files: [
+				{ id: 1, path: 'Sample.Movie.2024.mkv', bytes: 2147483648, selected: 1 },
+				{ id: 2, path: 'unselected.nfo', bytes: 10, selected: 0 },
+			],
+			links: ['https://tr/l1'],
+		} as any);
+
+		await handleShowInfoForTorrin(
+			torrent,
+			'https://tr.test',
+			'key',
+			setList,
+			torrentDB,
+			setSelected
+		);
+
+		expect(getTorrinTorrentInfo).toHaveBeenCalledWith('https://tr.test', 'key', 'abc123');
+		expect(modalMock.showLoading).toHaveBeenCalled();
+		expect(modalMock.fire).toHaveBeenCalledTimes(1);
+		const html = modalMock.fire.mock.calls[0][0].html as string;
+		expect(html).toContain('Sample.Movie.2024.mkv');
+		// only the selected file gets a play button
+		expect(html).toContain('data-tr-play="0"');
+		expect(html).not.toContain('unselected.nfo');
+	});
+
+	it('escapes html in the filename', async () => {
+		vi.mocked(getTorrinTorrentInfo).mockResolvedValue({
+			id: 'abc123',
+			filename: '<script>x</script>',
+			status: 'downloaded',
+			bytes: 1,
+			files: [],
+			links: [],
+		} as any);
+
+		await handleShowInfoForTorrin(
+			torrent,
+			'https://tr.test',
+			'key',
+			setList,
+			torrentDB,
+			setSelected
+		);
+
+		const html = modalMock.fire.mock.calls[0][0].html as string;
+		expect(html).not.toContain('<script>x</script>');
+		expect(html).toContain('&lt;script&gt;');
+	});
+
+	it('closes the modal and toasts on fetch error', async () => {
+		vi.mocked(getTorrinTorrentInfo).mockRejectedValue(new Error('offline'));
+
+		await handleShowInfoForTorrin(
+			torrent,
+			'https://tr.test',
+			'key',
+			setList,
+			torrentDB,
+			setSelected
+		);
+
+		expect(modalMock.close).toHaveBeenCalled();
+		expect(toastMock.error).toHaveBeenCalledWith(expect.stringContaining('offline'));
+		expect(modalMock.fire).not.toHaveBeenCalled();
+	});
+});

--- a/src/utils/torrinInfo.ts
+++ b/src/utils/torrinInfo.ts
@@ -1,0 +1,106 @@
+import { getTorrinTorrentInfo, unrestrictTorrinLink } from '@/services/torrin';
+import UserTorrentDB from '@/torrent/db';
+import { UserTorrent } from '@/torrent/userTorrent';
+import { Dispatch, SetStateAction } from 'react';
+import toast from 'react-hot-toast';
+import Modal from '../components/modals/modal';
+import { handleDeleteTrTorrent } from './deleteTorrent';
+
+const escapeHtml = (s: string): string =>
+	s.replace(
+		/[&<>"']/g,
+		(c) =>
+			({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string
+	);
+
+const toGb = (bytes: number): string => (bytes / 1024 ** 3).toFixed(2);
+
+export async function handleShowInfoForTorrin(
+	t: UserTorrent,
+	baseUrl: string,
+	apiKey: string,
+	setUserTorrentsList: (fn: (prev: UserTorrent[]) => UserTorrent[]) => void,
+	torrentDB: UserTorrentDB,
+	setSelectedTorrents: Dispatch<SetStateAction<Set<string>>>
+) {
+	Modal.showLoading();
+	let info;
+	try {
+		info = await getTorrinTorrentInfo(baseUrl, apiKey, t.id.substring(3));
+	} catch (error) {
+		Modal.close();
+		toast.error(`Torrin: ${error instanceof Error ? error.message : 'failed to load info'}`);
+		return;
+	}
+
+	const selectedFiles = info.files.filter((f) => f.selected);
+	const rows = selectedFiles
+		.map((f, i) => {
+			const name = f.path.split('/').pop() || f.path;
+			const hasLink = i < info.links.length;
+			return `<tr class="border-b border-gray-700">
+				<td class="py-1 pr-2 text-left text-sm text-gray-200" style="word-break:break-all">${escapeHtml(name)}</td>
+				<td class="whitespace-nowrap px-2 py-1 text-right text-xs text-gray-400">${toGb(f.bytes)} GB</td>
+				<td class="py-1 pl-2 text-right">${
+					hasLink
+						? `<button data-tr-play="${i}" class="haptic-sm rounded border border-green-500 bg-green-900/30 px-2 py-0.5 text-xs text-green-100">Play</button>`
+						: ''
+				}</td>
+			</tr>`;
+		})
+		.join('');
+
+	const html = `
+		<h1 class="mb-1 mt-2 text-lg font-bold text-gray-100" style="word-break:break-all">${escapeHtml(info.filename)}</h1>
+		<div class="mb-3 text-xs text-gray-400">${escapeHtml(info.status)} &middot; ${toGb(info.bytes)} GB &middot; ${selectedFiles.length} file(s)</div>
+		<div class="mb-3 flex justify-center">
+			<button id="tr-delete" class="haptic-sm rounded border-2 border-red-500 bg-red-900/30 px-3 py-1 text-sm text-red-100">Delete from Torrin</button>
+		</div>
+		<hr class="border-gray-600"/>
+		<div class="mt-2 max-h-72 overflow-y-auto text-left">
+			<table class="w-full table-auto"><tbody>${rows}</tbody></table>
+		</div>`;
+
+	await Modal.fire({
+		html,
+		showConfirmButton: false,
+		showCancelButton: false,
+		customClass: { popup: '!bg-gray-900 !text-gray-100 !px-4 !py-3' },
+		width: '640px',
+		showCloseButton: true,
+		didOpen: () => {
+			document.querySelectorAll<HTMLButtonElement>('[data-tr-play]').forEach((btn) => {
+				btn.addEventListener('click', async () => {
+					const idx = parseInt(btn.getAttribute('data-tr-play') || '0', 10);
+					const link = info.links[idx];
+					if (!link) return;
+					const original = btn.textContent;
+					btn.textContent = '...';
+					btn.disabled = true;
+					try {
+						const resp = await unrestrictTorrinLink(baseUrl, apiKey, link);
+						window.open(resp.download, '_blank');
+					} catch (e) {
+						toast.error('Torrin: could not get stream link');
+					} finally {
+						btn.textContent = original;
+						btn.disabled = false;
+					}
+				});
+			});
+
+			const deleteBtn = document.getElementById('tr-delete');
+			deleteBtn?.addEventListener('click', async () => {
+				const ok = await handleDeleteTrTorrent(baseUrl, apiKey, t.id);
+				if (!ok) return;
+				setUserTorrentsList((prev) => prev.filter((x) => x.id !== t.id));
+				await torrentDB.deleteById(t.id);
+				setSelectedTorrents((prev) => {
+					prev.delete(t.id);
+					return new Set(prev);
+				});
+				Modal.close();
+			});
+		},
+	});
+}

--- a/src/utils/torrinInfo.ts
+++ b/src/utils/torrinInfo.ts
@@ -6,7 +6,7 @@ import toast from 'react-hot-toast';
 import Modal from '../components/modals/modal';
 import { handleDeleteTrTorrent } from './deleteTorrent';
 
-const escapeHtml = (s: string): string =>
+export const escapeHtml = (s: string): string =>
 	s.replace(
 		/[&<>"']/g,
 		(c) =>

--- a/src/utils/torrinToken.test.ts
+++ b/src/utils/torrinToken.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { packTorrinToken, splitTorrinToken } from './torrinToken';
+
+describe('torrinToken', () => {
+	it('packs baseUrl and apiKey into a single token', () => {
+		expect(packTorrinToken('https://tr.test', 'key-123')).toBe('https://tr.test key-123');
+	});
+
+	it('splits a packed token back into parts', () => {
+		expect(splitTorrinToken('https://tr.test key-123')).toEqual({
+			baseUrl: 'https://tr.test',
+			apiKey: 'key-123',
+		});
+	});
+
+	it('round-trips', () => {
+		const packed = packTorrinToken('https://my.instance:8080', 'abc');
+		expect(splitTorrinToken(packed)).toEqual({
+			baseUrl: 'https://my.instance:8080',
+			apiKey: 'abc',
+		});
+	});
+
+	it('only splits on the first separator (apiKey may contain spaces)', () => {
+		expect(splitTorrinToken('https://tr.test key with spaces')).toEqual({
+			baseUrl: 'https://tr.test',
+			apiKey: 'key with spaces',
+		});
+	});
+
+	it('treats a token with no separator as apiKey-only', () => {
+		expect(splitTorrinToken('justapikey')).toEqual({ baseUrl: '', apiKey: 'justapikey' });
+	});
+});

--- a/src/utils/torrinToken.ts
+++ b/src/utils/torrinToken.ts
@@ -1,0 +1,11 @@
+const SEP = ' ';
+
+export function packTorrinToken(baseUrl: string, apiKey: string): string {
+	return `${baseUrl}${SEP}${apiKey}`;
+}
+
+export function splitTorrinToken(token: string): { baseUrl: string; apiKey: string } {
+	const idx = token.indexOf(SEP);
+	if (idx === -1) return { baseUrl: '', apiKey: token };
+	return { baseUrl: token.slice(0, idx), apiKey: token.slice(idx + 1) };
+}

--- a/src/utils/withAuth.tsx
+++ b/src/utils/withAuth.tsx
@@ -36,7 +36,9 @@ export const withAuth = <P extends object>(Component: ComponentType<P>) => {
 		});
 		const [torrinKey] = useState(() => {
 			if (typeof window !== 'undefined') {
-				return localStorage.getItem('torrin:apiKey');
+				return (
+					localStorage.getItem('torrin:apiKey') && localStorage.getItem('torrin:baseUrl')
+				);
 			}
 			return null;
 		});
@@ -79,7 +81,16 @@ export const withAuth = <P extends object>(Component: ComponentType<P>) => {
 				}
 				setIsLoading(false);
 			}
-		}, [rdKey, rdLoading, rdIsRefreshing, hasRefreshCredentials, adKey, tbKey, torrinKey, router]);
+		}, [
+			rdKey,
+			rdLoading,
+			rdIsRefreshing,
+			hasRefreshCredentials,
+			adKey,
+			tbKey,
+			torrinKey,
+			router,
+		]);
 
 		// Loading screen state tracking
 		useEffect(() => {

--- a/src/utils/withAuth.tsx
+++ b/src/utils/withAuth.tsx
@@ -34,6 +34,12 @@ export const withAuth = <P extends object>(Component: ComponentType<P>) => {
 			}
 			return null;
 		});
+		const [torrinKey] = useState(() => {
+			if (typeof window !== 'undefined') {
+				return localStorage.getItem('torrin:apiKey');
+			}
+			return null;
+		});
 
 		// Check for refresh credentials
 		const [hasRefreshCredentials] = useState(() => {
@@ -56,6 +62,7 @@ export const withAuth = <P extends object>(Component: ComponentType<P>) => {
 				!rdKey &&
 				!adKey &&
 				!tbKey &&
+				!torrinKey &&
 				router.pathname !== START_ROUTE &&
 				!router.pathname.endsWith(LOGIN_ROUTE) &&
 				!rdLoading &&
@@ -72,7 +79,7 @@ export const withAuth = <P extends object>(Component: ComponentType<P>) => {
 				}
 				setIsLoading(false);
 			}
-		}, [rdKey, rdLoading, rdIsRefreshing, hasRefreshCredentials, adKey, tbKey, router]);
+		}, [rdKey, rdLoading, rdIsRefreshing, hasRefreshCredentials, adKey, tbKey, torrinKey, router]);
 
 		// Loading screen state tracking
 		useEffect(() => {


### PR DESCRIPTION
Adds Torrin as a debrid option alongside RD/AD/Torbox: login, library, cast, and add-from-search/hashlists. It's open-source and RD-API-compatible, so users can point at torrin.app or self-host. Tests included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end Torrin (“TR”) support: Torrin login/connect, library refresh, and torrent add/delete across the app.
  * Introduced Torrin casting with cast settings (including the new sky accent), TR magnet/torrent casting with loading, and Stremio catalog/stream/manifest integration plus a “manage casted links” page.
  * Added persistent cast profile + size-limit syncing and TR availability checks for search results.
* **Bug Fixes**
  * Updated Stremio meta routing to correctly skip Torrin-prefixed IDs (`dmm-tr:`).
* **Tests**
  * Expanded Vitest coverage for Torrin UI, hooks, utilities, and all Torrin/Stremio endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->