### PR TITLE
fix: gracefully handle missing or insecure DMMCAST_SALT

### DIFF
--- a/src/pages/api/zurg/register-api-key.ts
+++ b/src/pages/api/zurg/register-api-key.ts
@@ -18,9 +18,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
 		// Validate the salt matches environment variable
 		const expectedSalt = process.env.DMMCAST_SALT;
-		if (!expectedSalt) {
-			console.error('DMMCAST_SALT environment variable is not set');
-			return res.status(500).json({ error: 'Server configuration error' });
+		if (!expectedSalt || expectedSalt === 'your-random-salt-here') {
+			console.error('DMMCAST_SALT environment variable is not set securely');
+			return res.status(500).json({ error: 'Server configuration error: DMMCAST_SALT must be configured securely' });
 		}
 
 		if (authHeader !== expectedSalt) {

--- a/src/utils/allDebridCastApiHelpers.ts
+++ b/src/utils/allDebridCastApiHelpers.ts
@@ -27,14 +27,15 @@ export const validateApiKey = (req: NextApiRequest, res: NextApiResponse): strin
 };
 
 const deriveUserId = (username: string): string => {
-	const salt = process.env.DMMCAST_SALT;
-	if (!salt) {
-		throw new Error('DMMCAST_SALT environment variable is not set');
+	let salt = process.env.DMMCAST_SALT;
+	if (!salt || salt === 'your-random-salt-here') {
+		const globalAny = global as any;
+		salt = globalAny.__DMMCAST_TEMP_SALT || (globalAny.__DMMCAST_TEMP_SALT = crypto.randomBytes(32).toString('hex'));
 	}
 
 	// Prefixed with 'alldebrid:' to ensure different IDs from RD/TB
 	const hmac = crypto
-		.createHmac('sha256', salt)
+		.createHmac('sha256', salt as string)
 		.update(`alldebrid:${username}`)
 		.digest('base64url'); // base64url is URL-safe (no +, /, or =)
 

--- a/src/utils/castApiHelpers.ts
+++ b/src/utils/castApiHelpers.ts
@@ -50,12 +50,16 @@ export const generateUserId = async (token: string): Promise<string> => {
 			throw new Error('Invalid username');
 		}
 
-		const salt = process.env.DMMCAST_SALT;
-		if (!salt) {
-			throw new Error('DMMCAST_SALT environment variable is not set');
+		let salt = process.env.DMMCAST_SALT;
+		if (!salt || salt === 'your-random-salt-here') {
+			console.warn('WARNING: DMMCAST_SALT is missing or insecure in environment variables. Using a temporary random salt. Cast profiles will not persist across server restarts. Please set DMMCAST_SALT securely in your .env file.');
+			
+			// We can't persist it, but we can store it in memory for the session
+			const globalAny = global as any;
+			salt = globalAny.__DMMCAST_TEMP_SALT || (globalAny.__DMMCAST_TEMP_SALT = crypto.randomBytes(32).toString('hex'));
 		}
 
-		const hmac = crypto.createHmac('sha256', salt).update(username).digest('base64url');
+		const hmac = crypto.createHmac('sha256', salt as string).update(username).digest('base64url');
 
 		// Return 12 characters for much better collision resistance
 		// With 62^12 possible values, collision probability is effectively 0 for millions of users
@@ -73,9 +77,10 @@ export const generateLegacyUserId = async (token: string): Promise<string> => {
 			throw new Error('Invalid username');
 		}
 
-		const salt = process.env.DMMCAST_SALT;
-		if (!salt) {
-			throw new Error('DMMCAST_SALT environment variable is not set');
+		let salt = process.env.DMMCAST_SALT;
+		if (!salt || salt === 'your-random-salt-here') {
+			const globalAny = global as any;
+			salt = globalAny.__DMMCAST_TEMP_SALT || (globalAny.__DMMCAST_TEMP_SALT = crypto.randomBytes(32).toString('hex'));
 		}
 
 		const hash = crypto

--- a/src/utils/torboxCastApiHelpers.ts
+++ b/src/utils/torboxCastApiHelpers.ts
@@ -25,13 +25,14 @@ export const validateApiKey = (req: NextApiRequest, res: NextApiResponse): strin
 };
 
 const deriveUserId = (email: string): string => {
-	const salt = process.env.DMMCAST_SALT;
-	if (!salt) {
-		throw new Error('DMMCAST_SALT environment variable is not set');
+	let salt = process.env.DMMCAST_SALT;
+	if (!salt || salt === 'your-random-salt-here') {
+		const globalAny = global as any;
+		salt = globalAny.__DMMCAST_TEMP_SALT || (globalAny.__DMMCAST_TEMP_SALT = crypto.randomBytes(32).toString('hex'));
 	}
 
 	// Prefixed with 'torbox:' to ensure different IDs from RD
-	const hmac = crypto.createHmac('sha256', salt).update(`torbox:${email}`).digest('base64url'); // base64url is URL-safe (no +, /, or =)
+	const hmac = crypto.createHmac('sha256', salt as string).update(`torbox:${email}`).digest('base64url'); // base64url is URL-safe (no +, /, or =)
 
 	// Return 12 characters for collision resistance
 	return hmac.slice(0, 12);


### PR DESCRIPTION
If a self-hoster follows the docs and leaves \DMMCAST_SALT=your-random-salt-here\ or omits it, the Next.js server crashes in \generateUserId\ and throws a 500 error on the \/api/stremio/cast/saveProfile\ endpoint. It also leaves their Cast IDs predictably insecure.

This PR adds a fallback that warns the console and generates an ephemeral in-memory random salt for the session to prevent crashes, while also explicitly rejecting the default insecure salt in the zurg API key generator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security validation by rejecting insecure placeholder salt configuration during API-key registration.
  * Casting services now continue functioning when secure salt configuration is unavailable.
  * User profiles created without a configured secure salt may not persist after a server restart.
  * Added clearer security-related configuration feedback and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->